### PR TITLE
Replace Monoid policy instance by BoundedSemillatice

### DIFF
--- a/modules/core/shared/src/main/scala/retry/RetryPolicy.scala
+++ b/modules/core/shared/src/main/scala/retry/RetryPolicy.scala
@@ -1,7 +1,7 @@
 package retry
 
 import cats.Applicative
-import cats.kernel.Monoid
+import cats.kernel.BoundedSemilattice
 import retry.PolicyDecision._
 
 import scala.concurrent.duration.Duration
@@ -18,10 +18,10 @@ object RetryPolicy {
   ): RetryPolicy[M] =
     RetryPolicy[M](decideNextRetry = retryStatus => M.pure(f(retryStatus)))
 
-  implicit def monoidForRetryPolicy[M[_]](
+  implicit def boundedSemilatticeForRetryPolicy[M[_]](
       implicit M: Applicative[M]
-  ): Monoid[RetryPolicy[M]] =
-    new Monoid[RetryPolicy[M]] {
+  ): BoundedSemilattice[RetryPolicy[M]] =
+    new BoundedSemilattice[RetryPolicy[M]] {
 
       override def empty: RetryPolicy[M] =
         RetryPolicies.constantDelay[M](Duration.Zero)

--- a/modules/core/shared/src/test/scala/retry/RetryPolicySpec.scala
+++ b/modules/core/shared/src/test/scala/retry/RetryPolicySpec.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration._
 
 class RetryPolicySpec extends FlatSpec {
 
-  behavior of "Monoid append"
+  behavior of "BoundedSemillatice append"
 
   it should "give up if either of the composed policies decides to give up" in {
     val alwaysGiveUp = RetryPolicy.lift[Id](_ => PolicyDecision.GiveUp)

--- a/modules/docs/src/main/tut/docs/policies.md
+++ b/modules/docs/src/main/tut/docs/policies.md
@@ -39,7 +39,7 @@ There are also a few combinators to transform policies, including:
 
 ## Composing policies
 
-Retry policies form a commutative monoid.
+Retry policies form a bounded semilattice (also know as commutative semilattice).
 
 The empty element is a simple policy that retries with no delay and never gives
 up.
@@ -50,7 +50,12 @@ The `combine` operation has the following semantics:
 * If both policies want to delay and retry, the *longer* of the two delays is
   chosen.
 
-A `Monoid` instance is provided in the companion object, so you can compose
+This way of combining policies imply:
+
+* That combining two identical policies result in this same policy.
+* That the order you combine policies doesn't affect the resulted policy.
+
+A `BoundedSemilattice` instance is provided in the companion object, so you can compose
 policies easily.
 
 For example, to retry up to 5 times, starting with a 10 ms delay and increasing
@@ -58,7 +63,7 @@ exponentially up to a maximum of 1 second:
 
 ```tut:book
 import cats.Id
-import cats.syntax.monoid._
+import cats.syntax.semigroup._
 import scala.concurrent.duration._
 import retry.RetryPolicies._
 


### PR DESCRIPTION
Having an instance of monoid wasn't reflecting all proprieties the
implementation had. This commit change it by an instance of
BoundedSemillatice that reflect the idempotent propriety.

Documentation have been updated accordingly.