### PR TITLE
Remove unused Jekyll stuff from Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,3 @@ cache:
 before_cache:
   - find $HOME/.sbt -name "*.lock" -type f -delete -print
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete -print
-before_install:
-  - export PATH=${PATH}:./vendor/bundle
-install:
-  - rvm use 2.2.8 --install --fuzzy
-  - gem update --system
-  - gem install sass
-  - gem install jekyll -v 3.2.1


### PR DESCRIPTION
This was a relic from when I was planning to publish the microsite via
Travis. For now I'm happy to publish it manually so I'll get rid of it.
It slows down the build and appears to have broken at some point
recently (see https://travis-ci.org/cb372/cats-retry/builds/472633596)