### PR TITLE
Introduce syntactic sugar

### DIFF
--- a/modules/core/shared/src/main/scala/retry/implicits.scala
+++ b/modules/core/shared/src/main/scala/retry/implicits.scala
@@ -1,0 +1,3 @@
+package retry
+
+object implicits extends syntax.AllSyntax

--- a/modules/core/shared/src/main/scala/retry/syntax/all.scala
+++ b/modules/core/shared/src/main/scala/retry/syntax/all.scala
@@ -1,0 +1,3 @@
+package retry.syntax
+
+trait AllSyntax extends RetrySyntax

--- a/modules/core/shared/src/main/scala/retry/syntax/package.scala
+++ b/modules/core/shared/src/main/scala/retry/syntax/package.scala
@@ -1,0 +1,5 @@
+package retry
+
+package object syntax {
+  object all extends AllSyntax
+}

--- a/modules/core/shared/src/main/scala/retry/syntax/retry.scala
+++ b/modules/core/shared/src/main/scala/retry/syntax/retry.scala
@@ -1,0 +1,46 @@
+package retry.syntax
+
+import cats.{Monad, MonadError}
+import retry.{RetryDetails, RetryPolicy, Sleep}
+
+trait RetrySyntax {
+  implicit final def retrySyntaxBase[M[_], A](
+      action: => M[A]): RetryingOps[M, A] =
+    new RetryingOps[M, A](action)
+
+}
+
+final class RetryingOps[M[_], A](action: => M[A]) {
+
+  def retryingM[E](wasSuccessful: A => Boolean)(
+      implicit policy: RetryPolicy[M],
+      onFailure: (A, RetryDetails) => M[Unit],
+      Mo: Monad[M],
+      S: Sleep[M]): M[A] =
+    retry.retryingM(
+      policy = policy,
+      wasSuccessful = wasSuccessful,
+      onFailure = onFailure
+    )(action)
+
+  def retryingOnAllErrors[E](implicit policy: RetryPolicy[M],
+                             onError: (E, RetryDetails) => M[Unit],
+                             ME: MonadError[M, E],
+                             S: Sleep[M]): M[A] =
+    retry.retryingOnAllErrors(
+      policy = policy,
+      onError = onError
+    )(action)
+
+  def retryingOnSomeErrors[E](isWorthRetrying: E => Boolean)(
+      implicit policy: RetryPolicy[M],
+      onError: (E, RetryDetails) => M[Unit],
+      ME: MonadError[M, E],
+      S: Sleep[M]): M[A] =
+    retry.retryingOnSomeErrors(
+      policy = policy,
+      isWorthRetrying = isWorthRetrying,
+      onError = onError
+    )(action)
+
+}

--- a/modules/core/shared/src/test/scala/retry/SyntaxSpec.scala
+++ b/modules/core/shared/src/test/scala/retry/SyntaxSpec.scala
@@ -1,0 +1,217 @@
+package retry
+
+import cats.Id
+import cats.instances.either._
+import org.scalatest.FlatSpec
+import retry.syntax.all._
+
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.duration._
+
+class SyntaxSpec extends FlatSpec {
+  type StringOr[A] = Either[String, A]
+
+  behavior of "retryingM"
+
+  it should "retry until the action succeeds" in new TestContext {
+    implicit val policy: RetryPolicy[Id] =
+      RetryPolicies.constantDelay[Id](1.second)
+    implicit def onFailure: (String, RetryDetails) => Id[Unit] = onError
+    def wasSuccessful(res: String): Id[Boolean]                = res.toInt > 3
+    val sleeps                                                 = ArrayBuffer.empty[FiniteDuration]
+
+    implicit val dummySleep: Sleep[Id] = new Sleep[Id] {
+      def sleep(delay: FiniteDuration): Id[Unit] = sleeps.append(delay)
+    }
+
+    def action: Id[String] = {
+      attempts = attempts + 1
+      attempts.toString
+    }
+
+    val finalResult: Id[String] = action.retryingM(wasSuccessful)
+
+    assert(finalResult == "4")
+    assert(attempts == 4)
+    assert(errors.toList == List("1", "2", "3"))
+    assert(delays.toList == List(1.second, 1.second, 1.second))
+    assert(sleeps.toList == delays.toList)
+    assert(!gaveUp)
+  }
+
+  it should "retry until the policy chooses to give up" in new TestContext {
+    implicit val policy: RetryPolicy[Id]                       = RetryPolicies.limitRetries[Id](2)
+    implicit def onFailure: (String, RetryDetails) => Id[Unit] = onError
+    def wasSuccessful(res: String): Id[Boolean]                = res.toInt > 3
+    implicit val dummySleep: Sleep[Id] =
+      new Sleep[Id] {
+        def sleep(delay: FiniteDuration): Id[Unit] = ()
+      }
+
+    def action: Id[String] = {
+      attempts = attempts + 1
+      attempts.toString
+    }
+
+    val finalResult: Id[String] = action.retryingM(wasSuccessful)
+
+    assert(finalResult == "3")
+    assert(attempts == 3)
+    assert(errors.toList == List("1", "2", "3"))
+    assert(delays.toList == List(Duration.Zero, Duration.Zero))
+    assert(gaveUp)
+  }
+
+  behavior of "retryingOnSomeErrors"
+
+  it should "retry until the action succeeds" in new TestContext {
+    implicit val sleepForEither: Sleep[StringOr] =
+      new Sleep[StringOr] {
+        def sleep(delay: FiniteDuration): StringOr[Unit] = Right(())
+      }
+
+    implicit val policy: RetryPolicy[StringOr] =
+      RetryPolicies.constantDelay[StringOr](1.second)
+    val isWorthRetrying: String => Boolean                          = (_: String) == "one more time"
+    implicit val onErrors: (String, RetryDetails) => StringOr[Unit] = onError
+
+    def action: StringOr[String] = {
+      attempts = attempts + 1
+      if (attempts < 3)
+        Left("one more time")
+      else
+        Right("yay")
+    }
+
+    val finalResult: StringOr[String] =
+      action.retryingOnSomeErrors(isWorthRetrying)
+
+    assert(finalResult == Right("yay"))
+    assert(attempts == 3)
+    assert(errors.toList == List("one more time", "one more time"))
+    assert(!gaveUp)
+  }
+
+  it should "retry only if the error is worth retrying" in new TestContext {
+    implicit val sleepForEither: Sleep[StringOr] =
+      new Sleep[StringOr] {
+        def sleep(delay: FiniteDuration): StringOr[Unit] = Right(())
+      }
+
+    implicit val policy: RetryPolicy[StringOr] =
+      RetryPolicies.constantDelay[StringOr](1.second)
+    implicit val onErrors: (String, RetryDetails) => StringOr[Unit] = onError
+
+    def action: StringOr[Nothing] = {
+      attempts = attempts + 1
+      if (attempts < 3)
+        Left("one more time")
+      else
+        Left("nope")
+    }
+
+    val finalResult =
+      action.retryingOnSomeErrors((_: String) == "one more time")
+
+    assert(finalResult == Left("nope"))
+    assert(attempts == 3)
+    assert(errors.toList == List("one more time", "one more time"))
+    assert(!gaveUp) // false because onError is only called when the error is worth retrying
+  }
+
+  it should "retry until the policy chooses to give up" in new TestContext {
+    implicit val sleepForEither: Sleep[StringOr] =
+      new Sleep[StringOr] {
+        def sleep(delay: FiniteDuration): StringOr[Unit] = Right(())
+      }
+
+    implicit val policy: RetryPolicy[StringOr] =
+      RetryPolicies.limitRetries[StringOr](2)
+    implicit val onErrors: (String, RetryDetails) => StringOr[Unit] = onError
+
+    def action: StringOr[Nothing] = {
+      attempts = attempts + 1
+
+      Left("one more time")
+    }
+
+    val finalResult: StringOr[Nothing] =
+      action.retryingOnSomeErrors((_: String) == "one more time")
+
+    assert(finalResult == Left("one more time"))
+    assert(attempts == 3)
+    assert(
+      errors.toList == List("one more time", "one more time", "one more time"))
+    assert(gaveUp)
+  }
+
+  behavior of "retryingOnAllErrors"
+
+  it should "retry until the action succeeds" in new TestContext {
+    implicit val sleepForEither: Sleep[StringOr] =
+      new Sleep[StringOr] {
+        def sleep(delay: FiniteDuration): StringOr[Unit] = Right(())
+      }
+
+    implicit val policy: RetryPolicy[StringOr] =
+      RetryPolicies.constantDelay[StringOr](1.second)
+    implicit val onErrors: (String, RetryDetails) => StringOr[Unit] = onError
+
+    def action: StringOr[String] = {
+      attempts = attempts + 1
+      if (attempts < 3)
+        Left("one more time")
+      else
+        Right("yay")
+    }
+
+    val finalResult: StringOr[String] = action.retryingOnAllErrors
+
+    assert(finalResult == Right("yay"))
+    assert(attempts == 3)
+    assert(errors.toList == List("one more time", "one more time"))
+    assert(!gaveUp)
+  }
+
+  it should "retry until the policy chooses to give up" in new TestContext {
+    implicit val sleepForEither: Sleep[StringOr] =
+      new Sleep[StringOr] {
+        def sleep(delay: FiniteDuration): StringOr[Unit] = Right(())
+      }
+
+    implicit val policy: RetryPolicy[StringOr] =
+      RetryPolicies.limitRetries[StringOr](2)
+    implicit val onErrors: (String, RetryDetails) => StringOr[Unit] = onError
+
+    def action: StringOr[Nothing] = {
+      attempts = attempts + 1
+      Left("one more time")
+    }
+
+    val finalResult: StringOr[Nothing] = action.retryingOnAllErrors
+
+    assert(finalResult == Left("one more time"))
+    assert(attempts == 3)
+    assert(
+      errors.toList == List("one more time", "one more time", "one more time"))
+    assert(gaveUp)
+  }
+
+  private class TestContext {
+
+    var attempts = 0
+    val errors   = ArrayBuffer.empty[String]
+    val delays   = ArrayBuffer.empty[FiniteDuration]
+    var gaveUp   = false
+
+    def onError(error: String, details: RetryDetails): Either[String, Unit] = {
+      errors.append(error)
+      details match {
+        case RetryDetails.WillDelayAndRetry(delay, _, _) => delays.append(delay)
+        case RetryDetails.GivingUp(_, _)                 => gaveUp = true
+      }
+      Right(())
+    }
+
+  }
+}

--- a/modules/docs/src/main/tut/docs/combinators.md
+++ b/modules/docs/src/main/tut/docs/combinators.md
@@ -147,3 +147,23 @@ You need to pass in:
 * the operation that you want to wrap with retries
 
 TODO example
+
+## Syntactic sugar
+
+Cats-retry include some syntactic sugar in order to reduce boilerplate.
+
+```scala
+import retry._
+import cats.Id
+import retry.syntax.all._
+
+implicit def noop[Id[_], A]: (A, RetryDetails) => Id[Unit] = retry.noop[Id, A]
+implicit val policy: RetryPolicy[Id]                       = RetryPolicies.limitRetries[Id](2)
+
+
+val httpClient = util.FlakyHttpClient()
+
+val flakyRequest: Id[String] = httpClient.getCatGif()
+
+flakyRequest.retryingOnAllErrors
+```


### PR DESCRIPTION
Having syntactic sugar allows to reduce boilerplate. We also push Policy
and onError handler implicitly to this end.

I must admit the design could be improved in the future by creating some
intermediate level of implicit passing. Also using call-by-name doesn't
allow AnyVal extending of the implicit extension class and so reducing
boilerplate

Tests and docs have been added,