### PR TITLE
Get rid of Travis Scala matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ scala:
   - 2.12.8
   - 2.13.0
 script:
-  - sbt test docs/tut scalafmtCheck test:scalafmtCheck scalafmtSbtCheck
+  - sbt ++$TRAVIS_SCALA_VERSION test docs/tut scalafmtCheck test:scalafmtCheck scalafmtSbtCheck
 cache:
   directories:
   - $HOME/.sbt

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,9 @@ language: scala
 jdk:
   - openjdk8
 scala:
-  - 2.11.12
-  - 2.12.8
   - 2.13.0
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION test docs/tut scalafmtCheck test:scalafmtCheck scalafmtSbtCheck
+  - sbt +test docs/tut scalafmtCheck test:scalafmtCheck scalafmtSbtCheck
 cache:
   directories:
   - $HOME/.sbt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
 scala:
   - 2.13.0
 script:
-  - sbt +test docs/tut scalafmtCheck test:scalafmtCheck scalafmtSbtCheck
+  - sbt -J-Xms4G -J-Xmx4G +test docs/tut scalafmtCheck test:scalafmtCheck scalafmtSbtCheck
 cache:
   directories:
   - $HOME/.sbt

--- a/modules/core/shared/src/test/scala/retry/RetryPoliciesSpec.scala
+++ b/modules/core/shared/src/test/scala/retry/RetryPoliciesSpec.scala
@@ -90,7 +90,7 @@ class RetryPoliciesSpec extends AnyFlatSpec with Checkers {
       val status = RetryStatus(retriesSoFar,
                                arbitraryCumulativeDelay,
                                arbitraryPreviousDelay)
-      for (i <- 1 to 1000) {
+      for (_ <- 1 to 1000) {
         val verdict = policy.decideNextRetry(status)
         val delay   = verdict.asInstanceOf[PolicyDecision.DelayAndRetry].delay
         assert(delay >= Duration.Zero)


### PR DESCRIPTION
Now we have a mixture of modules with different cross-build configs, using `++$TRAVIS_SCALA_VERSION` doesn't work properly. Replaced it with a single Travis build that calls `sbt +test`.