### PR TITLE
Avoid FiniteDuration overflow

### DIFF
--- a/modules/core/shared/src/test/scala/retry/RetryPoliciesSpec.scala
+++ b/modules/core/shared/src/test/scala/retry/RetryPoliciesSpec.scala
@@ -13,6 +13,9 @@ import scala.concurrent.duration._
 
 class RetryPoliciesSpec extends AnyFlatSpec with Checkers {
 
+  override implicit val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 100)
+
   implicit val arbRetryStatus: Arbitrary[RetryStatus] = Arbitrary {
     for {
       a <- Gen.choose(0, 1000)

--- a/modules/core/shared/src/test/scala/retry/RetryPolicyLawsSpec.scala
+++ b/modules/core/shared/src/test/scala/retry/RetryPolicyLawsSpec.scala
@@ -50,7 +50,8 @@ class RetryPolicyLawsSpec extends AnyFunSuite with Discipline with Checkers {
         RetryStatus(2, 20.millis, Some(10.millis)),
         RetryStatus(2, 30.millis, Some(20.millis)),
         RetryStatus(3, 70.millis, Some(40.millis)),
-        RetryStatus(4, 150.millis, Some(80.millis))
+        RetryStatus(4, 150.millis, Some(80.millis)),
+        RetryStatus(5, Long.MaxValue.nanos, Some(100.millis))
       )
     )
 

--- a/modules/core/shared/src/test/scala/retry/RetryPolicyLawsSpec.scala
+++ b/modules/core/shared/src/test/scala/retry/RetryPolicyLawsSpec.scala
@@ -16,6 +16,9 @@ import cats.Monad
 
 class RetryPolicyLawsSpec extends AnyFunSuite with Discipline with Checkers {
 
+  override implicit val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 100)
+
   implicit val cogenStatus: Cogen[RetryStatus] =
     Cogen { (seed, status) =>
       val a = Cogen[Int].perturb(seed, status.retriesSoFar)


### PR DESCRIPTION
Add checks to all the backoff-based retry policies to avoid creating a FiniteDuration longer than Long.MaxValue nanoseconds, because that results in an exception.

Also:

* add a test to reproduce the issue
* Override minSuccessful so we run 100 tests, not the ScalaTest default of 10

Fixes #96