### PR TITLE
Re-apply formatter

### DIFF
--- a/modules/cats-effect/shared/src/main/scala/retry/CatsEffect.scala
+++ b/modules/cats-effect/shared/src/main/scala/retry/CatsEffect.scala
@@ -5,12 +5,10 @@ import scala.concurrent.duration.FiniteDuration
 import cats.effect.Timer
 
 trait CatsEffect {
-
   implicit def sleepUsingTimer[F[_]](implicit timer: Timer[F]): Sleep[F] =
     new Sleep[F] {
       def sleep(delay: FiniteDuration): F[Unit] = timer.sleep(delay)
     }
-
 }
 
 object CatsEffect extends CatsEffect

--- a/modules/core/js/src/main/scala/retry/Sleep.scala
+++ b/modules/core/js/src/main/scala/retry/Sleep.scala
@@ -3,13 +3,9 @@ package retry
 import scala.concurrent.duration.FiniteDuration
 
 trait Sleep[M[_]] {
-
   def sleep(delay: FiniteDuration): M[Unit]
-
 }
 
 object Sleep {
-
   def apply[M[_]](implicit sleep: Sleep[M]): Sleep[M] = sleep
-
 }

--- a/modules/core/jvm/src/main/scala/retry/Sleep.scala
+++ b/modules/core/jvm/src/main/scala/retry/Sleep.scala
@@ -6,13 +6,10 @@ import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future, blocking}
 
 trait Sleep[M[_]] {
-
   def sleep(delay: FiniteDuration): M[Unit]
-
 }
 
 object Sleep {
-
   def apply[M[_]](implicit sleep: Sleep[M]): Sleep[M] = sleep
 
   implicit val threadSleepId: Sleep[Id] = new Sleep[Id] {

--- a/modules/core/shared/src/main/scala/retry/Fibonacci.scala
+++ b/modules/core/shared/src/main/scala/retry/Fibonacci.scala
@@ -1,7 +1,6 @@
 package retry
 
 object Fibonacci {
-
   def fibonacci(n: Int): Long = {
     if (n > 0)
       fib(n)._1
@@ -22,5 +21,4 @@ object Fibonacci {
       else
         (d, c + d)
   }
-
 }

--- a/modules/core/shared/src/main/scala/retry/PolicyDecision.scala
+++ b/modules/core/shared/src/main/scala/retry/PolicyDecision.scala
@@ -5,11 +5,9 @@ import scala.concurrent.duration.FiniteDuration
 sealed trait PolicyDecision
 
 object PolicyDecision {
-
   case object GiveUp extends PolicyDecision
 
   final case class DelayAndRetry(
       delay: FiniteDuration
   ) extends PolicyDecision
-
 }

--- a/modules/core/shared/src/main/scala/retry/RetryDetails.scala
+++ b/modules/core/shared/src/main/scala/retry/RetryDetails.scala
@@ -5,7 +5,6 @@ import scala.concurrent.duration.FiniteDuration
 sealed trait RetryDetails
 
 object RetryDetails {
-
   final case class GivingUp(
       totalRetries: Int,
       totalDelay: FiniteDuration
@@ -16,5 +15,4 @@ object RetryDetails {
       retriesSoFar: Int,
       cumulativeDelay: FiniteDuration
   ) extends RetryDetails
-
 }

--- a/modules/core/shared/src/main/scala/retry/RetryPolicies.scala
+++ b/modules/core/shared/src/main/scala/retry/RetryPolicies.scala
@@ -10,7 +10,6 @@ import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.util.Random
 
 object RetryPolicies {
-
   private val LongMax: BigInt = BigInt(Long.MaxValue)
 
   /*
@@ -113,7 +112,6 @@ object RetryPolicies {
       threshold: FiniteDuration,
       policy: RetryPolicy[M]
   ): RetryPolicy[M] = {
-
     def decideNextRetry(status: RetryStatus): M[PolicyDecision] =
       policy.decideNextRetry(status).map {
         case r @ DelayAndRetry(delay) =>
@@ -133,7 +131,6 @@ object RetryPolicies {
       threshold: FiniteDuration,
       policy: RetryPolicy[M]
   ): RetryPolicy[M] = {
-
     def decideNextRetry(status: RetryStatus): M[PolicyDecision] =
       policy.decideNextRetry(status).map {
         case r @ DelayAndRetry(delay) =>
@@ -143,5 +140,4 @@ object RetryPolicies {
 
     RetryPolicy[M](decideNextRetry)
   }
-
 }

--- a/modules/core/shared/src/main/scala/retry/RetryPolicy.scala
+++ b/modules/core/shared/src/main/scala/retry/RetryPolicy.scala
@@ -74,11 +74,9 @@ case class RetryPolicy[M[_]](
 
   def mapK[N[_]](nt: FunctionK[M, N]): RetryPolicy[N] =
     RetryPolicy(status => nt(decideNextRetry(status)))
-
 }
 
 object RetryPolicy {
-
   def lift[M[_]](
       f: RetryStatus => PolicyDecision
   )(
@@ -91,7 +89,6 @@ object RetryPolicy {
       implicit M: Applicative[M]
   ): BoundedSemilattice[RetryPolicy[M]] =
     new BoundedSemilattice[RetryPolicy[M]] {
-
       override def empty: RetryPolicy[M] =
         RetryPolicies.constantDelay[M](Duration.Zero)
 
@@ -100,5 +97,4 @@ object RetryPolicy {
           y: RetryPolicy[M]
       ): RetryPolicy[M] = x.join(y)
     }
-
 }

--- a/modules/core/shared/src/main/scala/retry/RetryStatus.scala
+++ b/modules/core/shared/src/main/scala/retry/RetryStatus.scala
@@ -7,17 +7,13 @@ final case class RetryStatus(
     cumulativeDelay: FiniteDuration,
     previousDelay: Option[FiniteDuration]
 ) {
-
   def addRetry(delay: FiniteDuration): RetryStatus = RetryStatus(
     retriesSoFar = this.retriesSoFar + 1,
     cumulativeDelay = this.cumulativeDelay + delay,
     previousDelay = Some(delay)
   )
-
 }
 
 object RetryStatus {
-
   val NoRetriesYet = RetryStatus(0, Duration.Zero, None)
-
 }

--- a/modules/core/shared/src/main/scala/retry/package.scala
+++ b/modules/core/shared/src/main/scala/retry/package.scala
@@ -6,7 +6,6 @@ import cats.syntax.apply._
 import scala.concurrent.duration.FiniteDuration
 
 package object retry {
-
   def retrying[A](
       policy: RetryPolicy[Id],
       wasSuccessful: A => Boolean,
@@ -23,7 +22,6 @@ package object retry {
   def retryingM[A] = new RetryingPartiallyApplied[A]
 
   private[retry] class RetryingPartiallyApplied[A] {
-
     def apply[M[_]](
         policy: RetryPolicy[M],
         wasSuccessful: A => Boolean,
@@ -35,7 +33,6 @@ package object retry {
         M: Monad[M],
         S: Sleep[M]
     ): M[A] = {
-
       def performNextStep(failedResult: A, nextStep: NextStep): M[A] =
         nextStep match {
           case NextStep.RetryAfterDelay(delay, updatedStatus) =>
@@ -61,13 +58,11 @@ package object retry {
 
       performAction(RetryStatus.NoRetriesYet)
     }
-
   }
 
   def retryingOnSomeErrors[A] = new RetryingOnSomeErrorsPartiallyApplied[A]
 
   private[retry] class RetryingOnSomeErrorsPartiallyApplied[A] {
-
     def apply[M[_], E](
         policy: RetryPolicy[M],
         isWorthRetrying: E => Boolean,
@@ -79,7 +74,6 @@ package object retry {
         ME: MonadError[M, E],
         S: Sleep[M]
     ): M[A] = {
-
       def performNextStep(error: E, nextStep: NextStep): M[A] =
         nextStep match {
           case NextStep.RetryAfterDelay(delay, updatedStatus) =>
@@ -103,13 +97,11 @@ package object retry {
 
       performAction(RetryStatus.NoRetriesYet)
     }
-
   }
 
   def retryingOnAllErrors[A] = new RetryingOnAllErrorsPartiallyApplied[A]
 
   private[retry] class RetryingOnAllErrorsPartiallyApplied[A] {
-
     def apply[M[_], E](
         policy: RetryPolicy[M],
         onError: (E, RetryDetails) => M[Unit]
@@ -120,7 +112,6 @@ package object retry {
         ME: MonadError[M, E],
         S: Sleep[M]
     ): M[A] = {
-
       def performNextStep(error: E, nextStep: NextStep): M[A] =
         nextStep match {
           case NextStep.RetryAfterDelay(delay, updatedStatus) =>
@@ -142,7 +133,6 @@ package object retry {
 
       performAction(RetryStatus.NoRetriesYet)
     }
-
   }
 
   def noop[M[_]: Monad, A]: (A, RetryDetails) => M[Unit] =
@@ -180,14 +170,11 @@ package object retry {
   private sealed trait NextStep
 
   private object NextStep {
-
     case object GiveUp extends NextStep
 
     final case class RetryAfterDelay(
         delay: FiniteDuration,
         updatedStatus: RetryStatus
     ) extends NextStep
-
   }
-
 }

--- a/modules/core/shared/src/main/scala/retry/syntax/retry.scala
+++ b/modules/core/shared/src/main/scala/retry/syntax/retry.scala
@@ -8,11 +8,9 @@ trait RetrySyntax {
       action: => M[A]
   ): RetryingOps[M, A] =
     new RetryingOps[M, A](action)
-
 }
 
 final class RetryingOps[M[_], A](action: => M[A]) {
-
   def retryingM[E](wasSuccessful: A => Boolean)(
       implicit policy: RetryPolicy[M],
       onFailure: (A, RetryDetails) => M[Unit],
@@ -47,5 +45,4 @@ final class RetryingOps[M[_], A](action: => M[A]) {
       isWorthRetrying = isWorthRetrying,
       onError = onError
     )(action)
-
 }

--- a/modules/core/shared/src/test/scala/retry/FibonacciSpec.scala
+++ b/modules/core/shared/src/test/scala/retry/FibonacciSpec.scala
@@ -3,7 +3,6 @@ package retry
 import org.scalatest.flatspec.AnyFlatSpec
 
 class FibonacciSpec extends AnyFlatSpec {
-
   it should "calculate the Fibonacci sequence" in {
     assert(Fibonacci.fibonacci(0) == 0)
     assert(Fibonacci.fibonacci(1) == 1)
@@ -15,5 +14,4 @@ class FibonacciSpec extends AnyFlatSpec {
     assert(Fibonacci.fibonacci(7) == 13)
     assert(Fibonacci.fibonacci(75) == 2111485077978050L)
   }
-
 }

--- a/modules/core/shared/src/test/scala/retry/PackageObjectSpec.scala
+++ b/modules/core/shared/src/test/scala/retry/PackageObjectSpec.scala
@@ -8,7 +8,6 @@ import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration._
 
 class PackageObjectSpec extends AnyFlatSpec {
-
   type StringOr[A] = Either[String, A]
 
   behavior of "retryingM"
@@ -194,7 +193,6 @@ class PackageObjectSpec extends AnyFlatSpec {
   }
 
   private class TestContext {
-
     var attempts = 0
     val errors   = ArrayBuffer.empty[String]
     val delays   = ArrayBuffer.empty[FiniteDuration]
@@ -208,6 +206,5 @@ class PackageObjectSpec extends AnyFlatSpec {
       }
       Right(())
     }
-
   }
 }

--- a/modules/core/shared/src/test/scala/retry/RetryPoliciesSpec.scala
+++ b/modules/core/shared/src/test/scala/retry/RetryPoliciesSpec.scala
@@ -12,7 +12,6 @@ import retry.PolicyDecision.{DelayAndRetry, GiveUp}
 import scala.concurrent.duration._
 
 class RetryPoliciesSpec extends AnyFlatSpec with Checkers {
-
   override implicit val generatorDrivenConfig: PropertyCheckConfiguration =
     PropertyCheckConfiguration(minSuccessful = 100)
 
@@ -244,5 +243,4 @@ class RetryPoliciesSpec extends AnyFlatSpec with Checkers {
     test(constantDelay(100.milliseconds), GiveUp)
     test(constantDelay(101.milliseconds), GiveUp)
   }
-
 }

--- a/modules/core/shared/src/test/scala/retry/RetryPolicyLawsSpec.scala
+++ b/modules/core/shared/src/test/scala/retry/RetryPolicyLawsSpec.scala
@@ -15,7 +15,6 @@ import cats.arrow.FunctionK
 import cats.Monad
 
 class RetryPolicyLawsSpec extends AnyFunSuite with Discipline with Checkers {
-
   override implicit val generatorDrivenConfig: PropertyCheckConfiguration =
     PropertyCheckConfiguration(minSuccessful = 100)
 
@@ -207,5 +206,4 @@ class RetryPolicyLawsSpec extends AnyFunSuite with Discipline with Checkers {
         Eq[RetryPolicy[Id]].eqv(p.followedBy(RetryPolicies.alwaysGiveUp), p)
     )
   }
-
 }

--- a/modules/core/shared/src/test/scala/retry/RetryPolicySpec.scala
+++ b/modules/core/shared/src/test/scala/retry/RetryPolicySpec.scala
@@ -7,7 +7,6 @@ import org.scalatest.flatspec.AnyFlatSpec
 import scala.concurrent.duration._
 
 class RetryPolicySpec extends AnyFlatSpec {
-
   behavior of "BoundedSemilattice append"
 
   it should "give up if either of the composed policies decides to give up" in {
@@ -41,5 +40,4 @@ class RetryPolicySpec extends AnyFlatSpec {
       ) == PolicyDecision.DelayAndRetry(2.seconds)
     )
   }
-
 }

--- a/modules/core/shared/src/test/scala/retry/SyntaxSpec.scala
+++ b/modules/core/shared/src/test/scala/retry/SyntaxSpec.scala
@@ -200,7 +200,6 @@ class SyntaxSpec extends AnyFlatSpec {
   }
 
   private class TestContext {
-
     var attempts = 0
     val errors   = ArrayBuffer.empty[String]
     val delays   = ArrayBuffer.empty[FiniteDuration]
@@ -214,6 +213,5 @@ class SyntaxSpec extends AnyFlatSpec {
       }
       Right(())
     }
-
   }
 }

--- a/modules/docs/src/main/scala/util/FlakyHttpClient.scala
+++ b/modules/docs/src/main/scala/util/FlakyHttpClient.scala
@@ -3,7 +3,6 @@ package util
 import java.io.IOException
 
 case class FlakyHttpClient() {
-
   private var i = 0
 
   def getCatGif(): String = {
@@ -14,5 +13,4 @@ case class FlakyHttpClient() {
       throw new IOException("Failed to download")
     }
   }
-
 }

--- a/modules/docs/src/main/scala/util/LoadedDie.scala
+++ b/modules/docs/src/main/scala/util/LoadedDie.scala
@@ -10,5 +10,4 @@ case class LoadedDie(rolls: Int*) {
     }
     rolls(i)
   }
-
 }

--- a/modules/monix/shared/src/main/scala/retry/Monix.scala
+++ b/modules/monix/shared/src/main/scala/retry/Monix.scala
@@ -5,12 +5,10 @@ import monix.eval.Task
 import scala.concurrent.duration.FiniteDuration
 
 trait Monix {
-
   implicit val taskSleep: Sleep[Task] = new Sleep[Task] {
     def sleep(delay: FiniteDuration): Task[Unit] =
       Task.sleep(delay)
   }
-
 }
 
 object Monix extends Monix

--- a/modules/monix/shared/src/test/scala/retry/MonixSpec.scala
+++ b/modules/monix/shared/src/test/scala/retry/MonixSpec.scala
@@ -11,7 +11,6 @@ import scala.concurrent.duration._
 import scala.util.Success
 
 class MonixSpec extends AnyFlatSpec {
-
   behavior of "retryingM"
 
   it should "retry until the action succeeds" in new TestContext {
@@ -41,7 +40,6 @@ class MonixSpec extends AnyFlatSpec {
   }
 
   private class TestContext {
-
     var attempts = 0
     val errors   = ArrayBuffer.empty[Int]
     val delays   = ArrayBuffer.empty[FiniteDuration]
@@ -55,6 +53,5 @@ class MonixSpec extends AnyFlatSpec {
       }
       Task(())
     }
-
   }
 }


### PR DESCRIPTION
Apparently scalafmt's formatting rules changed between 2.2.1 and 2.2.2. That's kind of annoying.