### PR TITLE
Apparently we are supposed to use the pull_request event?

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 on:
+  pull_request:
   push:
+    branches:
+      - master
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
References:

https://github.com/postmanlabs/postman-docs/blob/eb7f6d8545a32f32cef5d549622d61b6987e6009/.github/workflows/ci.yml

https://github.community/t5/GitHub-Actions/Github-Workflow-not-running-from-pull-request-from-forked/td-p/32979/page/3

https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#pull-request-events-for-forked-repositories