### PR TITLE
Fix accidental eager evaluation of action

### DIFF
--- a/modules/core/jvm/src/test/scala/retry/PackageObjectLazinessSpec.scala
+++ b/modules/core/jvm/src/test/scala/retry/PackageObjectLazinessSpec.scala
@@ -1,0 +1,55 @@
+package retry
+
+import cats.instances.future._
+import org.scalatest.flatspec.AnyFlatSpec
+
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.duration._
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class PackageObjectLazinessSpec extends AnyFlatSpec {
+  behavior of "retryingM"
+
+  // this test reproduces issue #116
+  it should "not evaluate the next attempt until it has finished sleeping" in new TestContext {
+    val policy = RetryPolicies.constantDelay[Future](5.second)
+
+    // Kick off an operation which will fail, wait 5 seconds, and repeat forever, in a Future
+    val _ = retryingM[String][Future](
+      policy,
+      _ => false,
+      (a, retryDetails) => Future.successful(onError(a, retryDetails))
+    ) {
+      Future {
+        attempts = attempts + 1
+        attempts.toString
+      }
+    }
+
+    // Wait for the first attempt to complete. By now we should be part way through the first delay.
+    Thread.sleep(1000)
+
+    // Assert that we haven't eagerly evaluated any more attempts.
+    assert(attempts == 1)
+    assert(errors.toList == List("1"))
+    assert(delays.toList == List(5.second))
+  }
+
+  private class TestContext {
+    var attempts = 0
+    val errors   = ArrayBuffer.empty[String]
+    val delays   = ArrayBuffer.empty[FiniteDuration]
+    var gaveUp   = false
+
+    def onError(error: String, details: RetryDetails): Future[Unit] =
+      Future.successful {
+        errors.append(error)
+        details match {
+          case RetryDetails.WillDelayAndRetry(delay, _, _) =>
+            delays.append(delay)
+          case RetryDetails.GivingUp(_, _) => gaveUp = true
+        }
+      }
+  }
+}

--- a/modules/core/shared/src/main/scala/retry/package.scala
+++ b/modules/core/shared/src/main/scala/retry/package.scala
@@ -1,7 +1,6 @@
 import cats.{Id, Monad, MonadError}
 import cats.syntax.functor._
 import cats.syntax.flatMap._
-import cats.syntax.apply._
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -36,7 +35,7 @@ package object retry {
       def performNextStep(failedResult: A, nextStep: NextStep): M[A] =
         nextStep match {
           case NextStep.RetryAfterDelay(delay, updatedStatus) =>
-            S.sleep(delay) *> performAction(updatedStatus)
+            S.sleep(delay) >> performAction(updatedStatus)
           case NextStep.GiveUp =>
             M.pure(failedResult)
         }
@@ -77,7 +76,7 @@ package object retry {
       def performNextStep(error: E, nextStep: NextStep): M[A] =
         nextStep match {
           case NextStep.RetryAfterDelay(delay, updatedStatus) =>
-            S.sleep(delay) *> performAction(updatedStatus)
+            S.sleep(delay) >> performAction(updatedStatus)
           case NextStep.GiveUp =>
             ME.raiseError[A](error)
         }
@@ -115,7 +114,7 @@ package object retry {
       def performNextStep(error: E, nextStep: NextStep): M[A] =
         nextStep match {
           case NextStep.RetryAfterDelay(delay, updatedStatus) =>
-            S.sleep(delay) *> performAction(updatedStatus)
+            S.sleep(delay) >> performAction(updatedStatus)
           case NextStep.GiveUp =>
             ME.raiseError[A](error)
         }


### PR DESCRIPTION
After an attempt has failed, we need to do the following *sequentially*:

1. delay for as long as the retry policy tells us to
2. execute another attempt

Unfortunately we were accidentally using `*>` to sequence these actions. This is eager in both arguments. That's not so bad when using cats-effect `IO`, but when using `Future` it means we start executing the next attempt before we execute the delay!

Replaced all occurrences of `*>` with `>>`, which is lazy in its second argument.

Fixes #116 