### PR TITLE
Simplify usage of sbt-ci-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,9 @@ jobs:
       - uses: olafurpg/setup-scala@v2
       - uses: olafurpg/setup-gpg@v2
       - name: Publish
-        run: sbt ci-release
+        run: sbt +test ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          CI_SNAPSHOT_RELEASE: test-and-publish
-          CI_RELEASE: test-and-publish-signed

--- a/build.sbt
+++ b/build.sbt
@@ -157,13 +157,5 @@ val root = project
   .settings(commonSettings)
   .settings(
     publishArtifact := false,
-    crossScalaVersions := Nil,
-    commands ++= Seq(
-      Command.command("test-and-publish") { currentState =>
-        "+test" :: "+publish" :: currentState
-      },
-      Command.command("test-and-publish-signed") { currentState =>
-        "+test" :: "+publishSigned" :: currentState
-      }
-    )
+    crossScalaVersions := Nil
   )


### PR DESCRIPTION
No need to mess around with custom sbt commands just to run the tests before releasing. I got a bit carried away last night.