### PR TITLE
Add ability to pretty print policies

### DIFF
--- a/modules/core/shared/src/main/scala/retry/RetryPolicies.scala
+++ b/modules/core/shared/src/main/scala/retry/RetryPolicies.scala
@@ -3,7 +3,10 @@ package retry
 import java.util.concurrent.TimeUnit
 
 import cats.Applicative
-import cats.implicits._
+import cats.syntax.functor._
+import cats.syntax.show._
+import cats.instances.finiteDuration._
+import cats.instances.int._
 import retry.PolicyDecision._
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
@@ -130,7 +133,7 @@ object RetryPolicies {
 
     RetryPolicy.withShow[M](
       decideNextRetry,
-      show"limitRetriesByDelay(threshold=$threshold, ${policy.show})"
+      show"limitRetriesByDelay(threshold=$threshold, $policy)"
     )
   }
 
@@ -152,7 +155,7 @@ object RetryPolicies {
 
     RetryPolicy.withShow[M](
       decideNextRetry,
-      show"limitRetriesByCumulativeDelay(threshold=$threshold, ${policy.show})"
+      show"limitRetriesByCumulativeDelay(threshold=$threshold, $policy)"
     )
   }
 }

--- a/modules/core/shared/src/main/scala/retry/RetryPolicies.scala
+++ b/modules/core/shared/src/main/scala/retry/RetryPolicies.scala
@@ -3,7 +3,7 @@ package retry
 import java.util.concurrent.TimeUnit
 
 import cats.Applicative
-import cats.syntax.functor._
+import cats.implicits._
 import retry.PolicyDecision._
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
@@ -34,13 +34,16 @@ object RetryPolicies {
     * Don't retry at all and always give up. Only really useful for combining with other policies.
     */
   def alwaysGiveUp[M[_]: Applicative]: RetryPolicy[M] =
-    RetryPolicy(Function.const(Applicative[M].pure(GiveUp)))
+    RetryPolicy.liftWithShow(Function.const(GiveUp), "alwaysGiveUp")
 
   /**
     * Delay by a constant amount before each retry. Never give up.
     */
   def constantDelay[M[_]: Applicative](delay: FiniteDuration): RetryPolicy[M] =
-    RetryPolicy.lift(_ => DelayAndRetry(delay))
+    RetryPolicy.liftWithShow(
+      Function.const(DelayAndRetry(delay)),
+      show"constantDelay($delay)"
+    )
 
   /**
     * Each delay is twice as long as the previous one. Never give up.
@@ -48,23 +51,23 @@ object RetryPolicies {
   def exponentialBackoff[M[_]: Applicative](
       baseDelay: FiniteDuration
   ): RetryPolicy[M] =
-    RetryPolicy.lift { status =>
+    RetryPolicy.liftWithShow({ status =>
       val delay =
         safeMultiply(baseDelay, Math.pow(2, status.retriesSoFar).toLong)
       DelayAndRetry(delay)
-    }
+    }, show"exponentialBackOff(baseDelay=$baseDelay)")
 
   /**
     * Retry without delay, giving up after the given number of retries.
     */
   def limitRetries[M[_]: Applicative](maxRetries: Int): RetryPolicy[M] =
-    RetryPolicy.lift { status =>
+    RetryPolicy.liftWithShow({ status =>
       if (status.retriesSoFar >= maxRetries) {
         GiveUp
       } else {
         DelayAndRetry(Duration.Zero)
       }
-    }
+    }, show"limitRetries(maxRetries=$maxRetries)")
 
   /**
     * Delay(n) = Delay(n - 2) + Delay(n - 1)
@@ -75,23 +78,29 @@ object RetryPolicies {
   def fibonacciBackoff[M[_]: Applicative](
       baseDelay: FiniteDuration
   ): RetryPolicy[M] =
-    RetryPolicy.lift { status =>
-      val delay =
-        safeMultiply(baseDelay, Fibonacci.fibonacci(status.retriesSoFar + 1))
-      DelayAndRetry(delay)
-    }
+    RetryPolicy.liftWithShow(
+      { status =>
+        val delay =
+          safeMultiply(baseDelay, Fibonacci.fibonacci(status.retriesSoFar + 1))
+        DelayAndRetry(delay)
+      },
+      show"fibonacciBackoff(baseDelay=$baseDelay)"
+    )
 
   /**
     * "Full jitter" backoff algorithm.
     * See https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
     */
   def fullJitter[M[_]: Applicative](baseDelay: FiniteDuration): RetryPolicy[M] =
-    RetryPolicy.lift { status =>
-      val e          = Math.pow(2, status.retriesSoFar).toLong
-      val maxDelay   = safeMultiply(baseDelay, e)
-      val delayNanos = (maxDelay.toNanos * Random.nextDouble()).toLong
-      DelayAndRetry(new FiniteDuration(delayNanos, TimeUnit.NANOSECONDS))
-    }
+    RetryPolicy.liftWithShow(
+      { status =>
+        val e          = Math.pow(2, status.retriesSoFar).toLong
+        val maxDelay   = safeMultiply(baseDelay, e)
+        val delayNanos = (maxDelay.toNanos * Random.nextDouble()).toLong
+        DelayAndRetry(new FiniteDuration(delayNanos, TimeUnit.NANOSECONDS))
+      },
+      show"fullJitter(baseDelay=$baseDelay)"
+    )
 
   /**
     * Set an upper bound on any individual delay produced by the given policy.
@@ -119,7 +128,10 @@ object RetryPolicies {
         case GiveUp => GiveUp
       }
 
-    RetryPolicy[M](decideNextRetry)
+    RetryPolicy.withShow[M](
+      decideNextRetry,
+      show"limitRetriesByDelay(threshold=$threshold, ${policy.show})"
+    )
   }
 
   /**
@@ -138,6 +150,9 @@ object RetryPolicies {
         case GiveUp => GiveUp
       }
 
-    RetryPolicy[M](decideNextRetry)
+    RetryPolicy.withShow[M](
+      decideNextRetry,
+      show"limitRetriesByCumulativeDelay(threshold=$threshold, ${policy.show})"
+    )
   }
 }

--- a/modules/core/shared/src/main/scala/retry/RetryPolicy.scala
+++ b/modules/core/shared/src/main/scala/retry/RetryPolicy.scala
@@ -97,19 +97,6 @@ object RetryPolicy {
   ): RetryPolicy[M] =
     RetryPolicy[M](decideNextRetry = retryStatus => M.pure(f(retryStatus)))
 
-  implicit def boundedSemilatticeForRetryPolicy[M[_]](
-      implicit M: Applicative[M]
-  ): BoundedSemilattice[RetryPolicy[M]] =
-    new BoundedSemilattice[RetryPolicy[M]] {
-      override def empty: RetryPolicy[M] =
-        RetryPolicies.constantDelay[M](Duration.Zero)
-
-      override def combine(
-          x: RetryPolicy[M],
-          y: RetryPolicy[M]
-      ): RetryPolicy[M] = x.join(y)
-    }
-
   def withShow[M[_]](
       decideNextRetry: RetryStatus => M[PolicyDecision],
       pretty: => String
@@ -124,6 +111,19 @@ object RetryPolicy {
       pretty: => String
   ): RetryPolicy[M] =
     withShow(rs => Applicative[M].pure(decideNextRetry(rs)), pretty)
+
+  implicit def boundedSemilatticeForRetryPolicy[M[_]](
+      implicit M: Applicative[M]
+  ): BoundedSemilattice[RetryPolicy[M]] =
+    new BoundedSemilattice[RetryPolicy[M]] {
+      override def empty: RetryPolicy[M] =
+        RetryPolicies.constantDelay[M](Duration.Zero)
+
+      override def combine(
+          x: RetryPolicy[M],
+          y: RetryPolicy[M]
+      ): RetryPolicy[M] = x.join(y)
+    }
 
   implicit def showForRetryPolicy[M[_]]: Show[RetryPolicy[M]] =
     Show.show(_.show)

--- a/modules/core/shared/src/main/scala/retry/RetryPolicy.scala
+++ b/modules/core/shared/src/main/scala/retry/RetryPolicy.scala
@@ -8,6 +8,7 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
 import cats.arrow.FunctionK
 import cats.implicits._
+import cats.Show
 
 case class RetryPolicy[M[_]](
     decideNextRetry: RetryStatus => M[PolicyDecision]
@@ -123,4 +124,7 @@ object RetryPolicy {
       pretty: => String
   ): RetryPolicy[M] =
     withShow(rs => Applicative[M].pure(decideNextRetry(rs)), pretty)
+
+  implicit def showForRetryPolicy[M[_]]: Show[RetryPolicy[M]] =
+    Show.show(_.show)
 }

--- a/modules/core/shared/src/main/scala/retry/RetryPolicy.scala
+++ b/modules/core/shared/src/main/scala/retry/RetryPolicy.scala
@@ -22,7 +22,7 @@ case class RetryPolicy[M[_]](
           case (GiveUp, pd) => pd
           case (pd, _)      => pd
         },
-      show"$show.followedBy(${rp.show})"
+      show"$show.followedBy($rp)"
     )
 
   /**
@@ -37,7 +37,7 @@ case class RetryPolicy[M[_]](
           case (DelayAndRetry(a), DelayAndRetry(b)) => DelayAndRetry(a max b)
           case _                                    => GiveUp
         },
-      show"$show.join(${rp.show})"
+      show"$show.join($rp)"
     )
 
   /**
@@ -54,7 +54,7 @@ case class RetryPolicy[M[_]](
           case (GiveUp, s @ DelayAndRetry(_))       => s
           case _                                    => GiveUp
         },
-      show"$show.meet(${rp.show})"
+      show"$show.meet($rp)"
     )
 
   def mapDelay(


### PR DESCRIPTION
Renders like this:

```scala
scala> RetryPolicies.capDelay(20.seconds, RetryPolicies.exponentialBackoff(1.second))
res70: retry.RetryPolicy[cats.package.Id] = exponentialBackOff(baseDelay=1 second).meet(constantDelay(20 seconds))
```

Should fix #123 