### PR TITLE
Update discipline-scalatest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,15 +71,15 @@ val core = crossProject(JVMPlatform, JSPlatform)
     name := "cats-retry",
     crossScalaVersions := scalaVersions,
     libraryDependencies ++= Seq(
-      "org.typelevel"     %%% "cats-core"                % catsVersion,
-      "org.typelevel"     %%% "cats-effect"              % catsEffectVersion,
-      "org.scalatest"     %%% "scalatest"                % scalatestVersion % Test,
-      "org.scalacheck"    %%% "scalacheck"               % scalacheckVersion % Test,
-      "org.typelevel"     %%% "cats-laws"                % catsVersion % Test,
-      "org.scalatest"     %%% "scalatest"                % scalatestVersion % Test,
-      "org.scalatestplus" %%% "scalacheck-1-14"          % scalaTestPlusVersion % Test,
-      "org.typelevel"     %%% "discipline-scalatest"     % disciplineVersion % Test,
-      "org.scalacheck"    %%% "scalacheck"               % scalacheckVersion % Test
+      "org.typelevel"     %%% "cats-core"            % catsVersion,
+      "org.typelevel"     %%% "cats-effect"          % catsEffectVersion,
+      "org.scalatest"     %%% "scalatest"            % scalatestVersion % Test,
+      "org.scalacheck"    %%% "scalacheck"           % scalacheckVersion % Test,
+      "org.typelevel"     %%% "cats-laws"            % catsVersion % Test,
+      "org.scalatest"     %%% "scalatest"            % scalatestVersion % Test,
+      "org.scalatestplus" %%% "scalacheck-1-14"      % scalaTestPlusVersion % Test,
+      "org.typelevel"     %%% "discipline-scalatest" % disciplineVersion % Test,
+      "org.scalacheck"    %%% "scalacheck"           % scalacheckVersion % Test
     )
   )
 val coreJVM = core.jvm
@@ -94,13 +94,13 @@ val alleycatsRetry = crossProject(JVMPlatform, JSPlatform)
     name := "alleycats-retry",
     crossScalaVersions := scalaVersions,
     libraryDependencies ++= Seq(
-      "org.scalatest"     %%% "scalatest"                % scalatestVersion     % Test,
-      "org.scalacheck"    %%% "scalacheck"               % scalacheckVersion    % Test,
-      "org.typelevel"     %%% "cats-laws"                % catsVersion          % Test,
-      "org.scalatest"     %%% "scalatest"                % scalatestVersion     % Test,
-      "org.scalatestplus" %%% "scalacheck-1-14"          % scalaTestPlusVersion % Test,
-      "org.typelevel"     %%% "discipline-scalatest"     % disciplineVersion    % Test,
-      "org.scalacheck"    %%% "scalacheck"               % scalacheckVersion    % Test
+      "org.scalatest"     %%% "scalatest"            % scalatestVersion     % Test,
+      "org.scalacheck"    %%% "scalacheck"           % scalacheckVersion    % Test,
+      "org.typelevel"     %%% "cats-laws"            % catsVersion          % Test,
+      "org.scalatest"     %%% "scalatest"            % scalatestVersion     % Test,
+      "org.scalatestplus" %%% "scalacheck-1-14"      % scalaTestPlusVersion % Test,
+      "org.typelevel"     %%% "discipline-scalatest" % disciplineVersion    % Test,
+      "org.scalacheck"    %%% "scalacheck"           % scalacheckVersion    % Test
     )
   )
 val alleycatsJVM = alleycatsRetry.jvm

--- a/build.sbt
+++ b/build.sbt
@@ -60,9 +60,9 @@ val catsVersion          = "2.0.0"
 val catsEffectVersion    = "2.0.0"
 val catsMtlVersion       = "0.7.0"
 val scalatestVersion     = "3.1.0"
-val scalaTestPlusVersion = "3.1.0.0-RC2"
+val scalaTestPlusVersion = "3.1.0.1"
 val scalacheckVersion    = "1.14.3"
-val disciplineVersion    = "1.0.0-RC2"
+val disciplineVersion    = "1.0.0-RC4"
 
 val core = crossProject(JVMPlatform, JSPlatform)
   .in(file("modules/core"))
@@ -77,7 +77,7 @@ val core = crossProject(JVMPlatform, JSPlatform)
       "org.scalacheck"    %%% "scalacheck"               % scalacheckVersion % Test,
       "org.typelevel"     %%% "cats-laws"                % catsVersion % Test,
       "org.scalatest"     %%% "scalatest"                % scalatestVersion % Test,
-      "org.scalatestplus" %%% "scalatestplus-scalacheck" % scalaTestPlusVersion % Test,
+      "org.scalatestplus" %%% "scalacheck-1-14"          % scalaTestPlusVersion % Test,
       "org.typelevel"     %%% "discipline-scalatest"     % disciplineVersion % Test,
       "org.scalacheck"    %%% "scalacheck"               % scalacheckVersion % Test
     )
@@ -98,7 +98,7 @@ val alleycatsRetry = crossProject(JVMPlatform, JSPlatform)
       "org.scalacheck"    %%% "scalacheck"               % scalacheckVersion    % Test,
       "org.typelevel"     %%% "cats-laws"                % catsVersion          % Test,
       "org.scalatest"     %%% "scalatest"                % scalatestVersion     % Test,
-      "org.scalatestplus" %%% "scalatestplus-scalacheck" % scalaTestPlusVersion % Test,
+      "org.scalatestplus" %%% "scalacheck-1-14"          % scalaTestPlusVersion % Test,
       "org.typelevel"     %%% "discipline-scalatest"     % disciplineVersion    % Test,
       "org.scalacheck"    %%% "scalacheck"               % scalacheckVersion    % Test
     )

--- a/modules/core/shared/src/test/scala/retry/RetryPolicyLawsSpec.scala
+++ b/modules/core/shared/src/test/scala/retry/RetryPolicyLawsSpec.scala
@@ -6,7 +6,7 @@ import cats.kernel.laws.discipline.BoundedSemilatticeTests
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.scalacheck.Checkers
-import org.typelevel.discipline.scalatest.Discipline
+import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 
 import scala.concurrent.duration._
 import cats.laws.discipline.ExhaustiveCheck
@@ -14,7 +14,10 @@ import cats.laws.discipline.eq.catsLawsEqForFn1Exhaustive
 import cats.arrow.FunctionK
 import cats.Monad
 
-class RetryPolicyLawsSpec extends AnyFunSuite with Discipline with Checkers {
+class RetryPolicyLawsSpec
+    extends AnyFunSuite
+    with FunSuiteDiscipline
+    with Checkers {
   override implicit val generatorDrivenConfig: PropertyCheckConfiguration =
     PropertyCheckConfiguration(minSuccessful = 100)
 


### PR DESCRIPTION
Supersedes #158, which fails because there is a breaking change in this RC.