### PR TITLE
Update libraries (cats, cats-effect, cats-mtl, scalatest), drop Scala 2.11 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,7 @@ val core = crossProject(JVMPlatform, JSPlatform)
       "org.typelevel"     %%% "discipline-scalatest" % disciplineVersion % Test,
       "org.scalacheck"    %%% "scalacheck"           % scalacheckVersion % Test
     ),
-    mimaPreviousArtifacts := Set("com.github.cb372" %%% "cats-retry" % "1.1.0")
+    mimaPreviousArtifacts := Set.empty
   )
 val coreJVM = core.jvm
 val coreJS  = core.js
@@ -103,9 +103,7 @@ val alleycatsRetry = crossProject(JVMPlatform, JSPlatform)
       "org.typelevel"     %%% "discipline-scalatest" % disciplineVersion    % Test,
       "org.scalacheck"    %%% "scalacheck"           % scalacheckVersion    % Test
     ),
-    mimaPreviousArtifacts := Set(
-      "com.github.cb372" %%% "alleycats-retry" % "1.1.0"
-    )
+    mimaPreviousArtifacts := Set.empty
   )
 val alleycatsJVM = alleycatsRetry.jvm
 val alleycatsJS  = alleycatsRetry.js
@@ -122,9 +120,7 @@ val mtlRetry = crossProject(JVMPlatform, JSPlatform)
       "org.typelevel" %%% "cats-mtl"  % catsMtlVersion,
       "org.scalatest" %%% "scalatest" % scalatestVersion % Test
     ),
-    mimaPreviousArtifacts := Set(
-      "com.github.cb372" %%% "cats-retry-mtl" % "1.1.0"
-    )
+    mimaPreviousArtifacts := Set.empty
   )
 val mtlJVM = mtlRetry.jvm
 val mtlJS  = mtlRetry.js

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,8 @@
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
-lazy val scalaVersion213 = "2.13.0"
-lazy val scalaVersion212 = "2.12.10"
-lazy val scalaVersion211 = "2.11.12"
-lazy val scalaVersions   = List(scalaVersion213, scalaVersion212, scalaVersion211)
+lazy val scalaVersion213 = "2.13.3"
+lazy val scalaVersion212 = "2.12.12"
+lazy val scalaVersions   = List(scalaVersion213, scalaVersion212)
 
 ThisBuild / scalaVersion := scalaVersion212
 
@@ -57,13 +56,13 @@ val moduleSettings = commonSettings ++ Seq(
   scalafmtOnCompile := true
 )
 
-val catsVersion          = "2.0.0"
-val catsEffectVersion    = "2.0.0"
-val catsMtlVersion       = "0.7.0"
-val scalatestVersion     = "3.2.0"
-val scalaTestPlusVersion = "3.2.0.0"
+val catsVersion          = "2.2.0"
+val catsEffectVersion    = "2.2.0"
+val catsMtlVersion       = "1.0.0"
+val scalatestVersion     = "3.2.2"
+val scalaTestPlusVersion = "3.2.2.0"
 val scalacheckVersion    = "1.14.3"
-val disciplineVersion    = "1.0.1"
+val disciplineVersion    = "2.0.1"
 
 val core = crossProject(JVMPlatform, JSPlatform)
   .in(file("modules/core"))
@@ -120,8 +119,8 @@ val mtlRetry = crossProject(JVMPlatform, JSPlatform)
     name := "cats-retry-mtl",
     crossScalaVersions := scalaVersions,
     libraryDependencies ++= Seq(
-      "org.typelevel" %%% "cats-mtl-core" % catsMtlVersion,
-      "org.scalatest" %%% "scalatest"     % scalatestVersion % Test
+      "org.typelevel" %%% "cats-mtl"  % catsMtlVersion,
+      "org.scalatest" %%% "scalatest" % scalatestVersion % Test
     ),
     mimaPreviousArtifacts := Set(
       "com.github.cb372" %%% "cats-retry-mtl" % "1.1.0"

--- a/modules/alleycats/jvm/src/main/scala/retry/alleycats/instances.scala
+++ b/modules/alleycats/jvm/src/main/scala/retry/alleycats/instances.scala
@@ -4,39 +4,32 @@ package alleycats
 import cats.{Eval, Id}
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Future, Promise}
-import java.util.concurrent.{ThreadFactory, Executors}
+import java.util.concurrent.Executors
 
 object instances {
-  implicit val threadSleepId: Sleep[Id] = new Sleep[Id] {
-    def sleep(delay: FiniteDuration): Id[Unit] = Thread.sleep(delay.toMillis)
-  }
+  implicit val threadSleepId: Sleep[Id] =
+    (delay: FiniteDuration) => Thread.sleep(delay.toMillis)
 
-  implicit val threadSleepEval: Sleep[Eval] = new Sleep[Eval] {
-    def sleep(delay: FiniteDuration): Eval[Unit] =
-      Eval.later(Thread.sleep(delay.toMillis))
-  }
+  implicit val threadSleepEval: Sleep[Eval] =
+    (delay: FiniteDuration) => Eval.later(Thread.sleep(delay.toMillis))
 
   private lazy val scheduler =
-    Executors.newSingleThreadScheduledExecutor(new ThreadFactory {
-      override def newThread(runnable: Runnable) = {
-        val t = new Thread(runnable)
-        t.setDaemon(true)
-        t.setName("cats-retry scheduler")
-        t
-      }
+    Executors.newSingleThreadScheduledExecutor((runnable: Runnable) => {
+      val t = new Thread(runnable)
+      t.setDaemon(true)
+      t.setName("cats-retry scheduler")
+      t
     })
 
   implicit val threadSleepFuture: Sleep[Future] =
-    new Sleep[Future] {
-      def sleep(delay: FiniteDuration): Future[Unit] = {
-        val promise = Promise[Unit]()
-        scheduler.schedule(new Runnable {
-          def run: Unit = {
-            promise.success(())
-            ()
-          }
-        }, delay.length, delay.unit)
-        promise.future
-      }
+    (delay: FiniteDuration) => {
+      val promise = Promise[Unit]()
+      scheduler.schedule(new Runnable {
+        def run(): Unit = {
+          promise.success(())
+          ()
+        }
+      }, delay.length, delay.unit)
+      promise.future
     }
 }

--- a/modules/core/shared/src/main/scala/retry/RetryPolicies.scala
+++ b/modules/core/shared/src/main/scala/retry/RetryPolicies.scala
@@ -5,8 +5,6 @@ import java.util.concurrent.TimeUnit
 import cats.Applicative
 import cats.syntax.functor._
 import cats.syntax.show._
-import cats.instances.finiteDuration._
-import cats.instances.int._
 import retry.PolicyDecision._
 
 import scala.concurrent.duration.{Duration, FiniteDuration}

--- a/modules/core/shared/src/main/scala/retry/Sleep.scala
+++ b/modules/core/shared/src/main/scala/retry/Sleep.scala
@@ -11,7 +11,5 @@ object Sleep {
   def apply[M[_]](implicit sleep: Sleep[M]): Sleep[M] = sleep
 
   implicit def sleepUsingTimer[F[_]](implicit timer: Timer[F]): Sleep[F] =
-    new Sleep[F] {
-      def sleep(delay: FiniteDuration): F[Unit] = timer.sleep(delay)
-    }
+    (delay: FiniteDuration) => timer.sleep(delay)
 }

--- a/modules/core/shared/src/test/scala/retry/PackageObjectSpec.scala
+++ b/modules/core/shared/src/test/scala/retry/PackageObjectSpec.scala
@@ -1,7 +1,6 @@
 package retry
 
 import cats.Id
-import cats.instances.either._
 import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.collection.mutable.ArrayBuffer
@@ -10,10 +9,7 @@ import scala.concurrent.duration._
 class PackageObjectSpec extends AnyFlatSpec {
   type StringOr[A] = Either[String, A]
 
-  implicit val sleepForEither: Sleep[StringOr] =
-    new Sleep[StringOr] {
-      def sleep(delay: FiniteDuration): StringOr[Unit] = Right(())
-    }
+  implicit val sleepForEither: Sleep[StringOr] = _ => Right(())
 
   behavior of "retryingM"
 
@@ -22,9 +18,8 @@ class PackageObjectSpec extends AnyFlatSpec {
 
     val sleeps = ArrayBuffer.empty[FiniteDuration]
 
-    implicit val dummySleep: Sleep[Id] = new Sleep[Id] {
-      def sleep(delay: FiniteDuration): Id[Unit] = sleeps.append(delay)
-    }
+    implicit val dummySleep: Sleep[Id] =
+      (delay: FiniteDuration) => sleeps.append(delay)
 
     val finalResult = retryingM[String][Id](
       policy,
@@ -46,10 +41,7 @@ class PackageObjectSpec extends AnyFlatSpec {
   it should "retry until the policy chooses to give up" in new TestContext {
     val policy = RetryPolicies.limitRetries[Id](2)
 
-    implicit val dummySleep: Sleep[Id] =
-      new Sleep[Id] {
-        def sleep(delay: FiniteDuration): Id[Unit] = ()
-      }
+    implicit val dummySleep: Sleep[Id] = _ => ()
 
     val finalResult = retryingM[String][Id](
       policy,
@@ -70,10 +62,7 @@ class PackageObjectSpec extends AnyFlatSpec {
   it should "retry in a stack-safe way" in new TestContext {
     val policy = RetryPolicies.limitRetries[Id](10000)
 
-    implicit val dummySleep: Sleep[Id] =
-      new Sleep[Id] {
-        def sleep(delay: FiniteDuration): Id[Unit] = ()
-      }
+    implicit val dummySleep: Sleep[Id] = _ => ()
 
     val finalResult = retryingM[String][Id](
       policy,
@@ -94,7 +83,7 @@ class PackageObjectSpec extends AnyFlatSpec {
   it should "retry until the action succeeds" in new TestContext {
     val policy = RetryPolicies.constantDelay[StringOr](1.second)
 
-    val finalResult = retryingOnSomeErrors(
+    val finalResult = retryingOnSomeErrors[String].apply[StringOr, String](
       policy,
       (_: String) == "one more time",
       onError
@@ -115,7 +104,7 @@ class PackageObjectSpec extends AnyFlatSpec {
   it should "retry only if the error is worth retrying" in new TestContext {
     val policy = RetryPolicies.constantDelay[StringOr](1.second)
 
-    val finalResult = retryingOnSomeErrors(
+    val finalResult = retryingOnSomeErrors[String].apply[StringOr, String](
       policy,
       (_: String) == "one more time",
       onError
@@ -136,7 +125,7 @@ class PackageObjectSpec extends AnyFlatSpec {
   it should "retry until the policy chooses to give up" in new TestContext {
     val policy = RetryPolicies.limitRetries[StringOr](2)
 
-    val finalResult = retryingOnSomeErrors(
+    val finalResult = retryingOnSomeErrors[String].apply[StringOr, String](
       policy,
       (_: String) == "one more time",
       onError
@@ -156,7 +145,7 @@ class PackageObjectSpec extends AnyFlatSpec {
   it should "retry in a stack-safe way" in new TestContext {
     val policy = RetryPolicies.limitRetries[StringOr](10000)
 
-    val finalResult = retryingOnSomeErrors(
+    val finalResult = retryingOnSomeErrors[String].apply[StringOr, String](
       policy,
       (_: String) == "one more time",
       onError
@@ -175,7 +164,7 @@ class PackageObjectSpec extends AnyFlatSpec {
   it should "retry until the action succeeds" in new TestContext {
     val policy = RetryPolicies.constantDelay[StringOr](1.second)
 
-    val finalResult = retryingOnAllErrors(
+    val finalResult = retryingOnAllErrors[String].apply[StringOr, String](
       policy,
       onError
     ) {
@@ -195,7 +184,7 @@ class PackageObjectSpec extends AnyFlatSpec {
   it should "retry until the policy chooses to give up" in new TestContext {
     val policy = RetryPolicies.limitRetries[StringOr](2)
 
-    val finalResult = retryingOnAllErrors(
+    val finalResult = retryingOnAllErrors[String].apply[StringOr, String](
       policy,
       onError
     ) {
@@ -214,7 +203,7 @@ class PackageObjectSpec extends AnyFlatSpec {
   it should "retry in a stack-safe way" in new TestContext {
     val policy = RetryPolicies.limitRetries[StringOr](10000)
 
-    val finalResult = retryingOnAllErrors(
+    val finalResult = retryingOnAllErrors[String].apply[StringOr, String](
       policy,
       onError
     ) {

--- a/modules/core/shared/src/test/scala/retry/PackageObjectSpec.scala
+++ b/modules/core/shared/src/test/scala/retry/PackageObjectSpec.scala
@@ -83,7 +83,7 @@ class PackageObjectSpec extends AnyFlatSpec {
   it should "retry until the action succeeds" in new TestContext {
     val policy = RetryPolicies.constantDelay[StringOr](1.second)
 
-    val finalResult = retryingOnSomeErrors[String].apply[StringOr, String](
+    val finalResult = retryingOnSomeErrors(
       policy,
       (_: String) == "one more time",
       onError
@@ -104,7 +104,7 @@ class PackageObjectSpec extends AnyFlatSpec {
   it should "retry only if the error is worth retrying" in new TestContext {
     val policy = RetryPolicies.constantDelay[StringOr](1.second)
 
-    val finalResult = retryingOnSomeErrors[String].apply[StringOr, String](
+    val finalResult = retryingOnSomeErrors(
       policy,
       (_: String) == "one more time",
       onError
@@ -125,7 +125,7 @@ class PackageObjectSpec extends AnyFlatSpec {
   it should "retry until the policy chooses to give up" in new TestContext {
     val policy = RetryPolicies.limitRetries[StringOr](2)
 
-    val finalResult = retryingOnSomeErrors[String].apply[StringOr, String](
+    val finalResult = retryingOnSomeErrors(
       policy,
       (_: String) == "one more time",
       onError
@@ -145,7 +145,7 @@ class PackageObjectSpec extends AnyFlatSpec {
   it should "retry in a stack-safe way" in new TestContext {
     val policy = RetryPolicies.limitRetries[StringOr](10000)
 
-    val finalResult = retryingOnSomeErrors[String].apply[StringOr, String](
+    val finalResult = retryingOnSomeErrors(
       policy,
       (_: String) == "one more time",
       onError
@@ -164,7 +164,7 @@ class PackageObjectSpec extends AnyFlatSpec {
   it should "retry until the action succeeds" in new TestContext {
     val policy = RetryPolicies.constantDelay[StringOr](1.second)
 
-    val finalResult = retryingOnAllErrors[String].apply[StringOr, String](
+    val finalResult = retryingOnAllErrors(
       policy,
       onError
     ) {
@@ -184,7 +184,7 @@ class PackageObjectSpec extends AnyFlatSpec {
   it should "retry until the policy chooses to give up" in new TestContext {
     val policy = RetryPolicies.limitRetries[StringOr](2)
 
-    val finalResult = retryingOnAllErrors[String].apply[StringOr, String](
+    val finalResult = retryingOnAllErrors(
       policy,
       onError
     ) {
@@ -203,7 +203,7 @@ class PackageObjectSpec extends AnyFlatSpec {
   it should "retry in a stack-safe way" in new TestContext {
     val policy = RetryPolicies.limitRetries[StringOr](10000)
 
-    val finalResult = retryingOnAllErrors[String].apply[StringOr, String](
+    val finalResult = retryingOnAllErrors(
       policy,
       onError
     ) {

--- a/modules/core/shared/src/test/scala/retry/RetryPoliciesSpec.scala
+++ b/modules/core/shared/src/test/scala/retry/RetryPoliciesSpec.scala
@@ -187,12 +187,12 @@ class RetryPoliciesSpec extends AnyFlatSpec with Checkers {
 
   it should "cap the delay" in {
     check { status: RetryStatus =>
-      capDelay(100.milliseconds, constantDelay(101.milliseconds))
+      capDelay(100.milliseconds, constantDelay[Id](101.milliseconds))
         .decideNextRetry(status) == DelayAndRetry(100.milliseconds)
     }
 
     check { status: RetryStatus =>
-      capDelay(100.milliseconds, constantDelay(99.milliseconds))
+      capDelay(100.milliseconds, constantDelay[Id](99.milliseconds))
         .decideNextRetry(status) == DelayAndRetry(99.milliseconds)
     }
   }
@@ -201,12 +201,12 @@ class RetryPoliciesSpec extends AnyFlatSpec with Checkers {
 
   it should "give up if the underlying policy chooses a delay greater than the threshold" in {
     check { status: RetryStatus =>
-      limitRetriesByDelay(100.milliseconds, constantDelay(101.milliseconds))
+      limitRetriesByDelay(100.milliseconds, constantDelay[Id](101.milliseconds))
         .decideNextRetry(status) == GiveUp
     }
 
     check { status: RetryStatus =>
-      limitRetriesByDelay(100.milliseconds, constantDelay(99.milliseconds))
+      limitRetriesByDelay(100.milliseconds, constantDelay[Id](99.milliseconds))
         .decideNextRetry(status) == DelayAndRetry(99.milliseconds)
     }
   }

--- a/modules/core/shared/src/test/scala/retry/SyntaxSpec.scala
+++ b/modules/core/shared/src/test/scala/retry/SyntaxSpec.scala
@@ -1,7 +1,6 @@
 package retry
 
 import cats.Id
-import cats.instances.either._
 import org.scalatest.flatspec.AnyFlatSpec
 import retry.syntax.all._
 
@@ -20,9 +19,8 @@ class SyntaxSpec extends AnyFlatSpec {
     def wasSuccessful(res: String): Id[Boolean]       = res.toInt > 3
     val sleeps                                        = ArrayBuffer.empty[FiniteDuration]
 
-    implicit val dummySleep: Sleep[Id] = new Sleep[Id] {
-      def sleep(delay: FiniteDuration): Id[Unit] = sleeps.append(delay)
-    }
+    implicit val dummySleep: Sleep[Id] =
+      (delay: FiniteDuration) => sleeps.append(delay)
 
     def action: Id[String] = {
       attempts = attempts + 1
@@ -41,11 +39,8 @@ class SyntaxSpec extends AnyFlatSpec {
   }
 
   it should "retry until the policy chooses to give up" in new TestContext {
-    val policy: RetryPolicy[Id] = RetryPolicies.limitRetries[Id](2)
-    implicit val dummySleep: Sleep[Id] =
-      new Sleep[Id] {
-        def sleep(delay: FiniteDuration): Id[Unit] = ()
-      }
+    val policy: RetryPolicy[Id]        = RetryPolicies.limitRetries[Id](2)
+    implicit val dummySleep: Sleep[Id] = _ => ()
 
     def action: Id[String] = {
       attempts = attempts + 1
@@ -64,10 +59,7 @@ class SyntaxSpec extends AnyFlatSpec {
   behavior of "retryingOnSomeErrors"
 
   it should "retry until the action succeeds" in new TestContext {
-    implicit val sleepForEither: Sleep[StringOr] =
-      new Sleep[StringOr] {
-        def sleep(delay: FiniteDuration): StringOr[Unit] = Right(())
-      }
+    implicit val sleepForEither: Sleep[StringOr] = _ => Right(())
 
     val policy: RetryPolicy[StringOr] =
       RetryPolicies.constantDelay[StringOr](1.second)
@@ -94,10 +86,7 @@ class SyntaxSpec extends AnyFlatSpec {
   }
 
   it should "retry only if the error is worth retrying" in new TestContext {
-    implicit val sleepForEither: Sleep[StringOr] =
-      new Sleep[StringOr] {
-        def sleep(delay: FiniteDuration): StringOr[Unit] = Right(())
-      }
+    implicit val sleepForEither: Sleep[StringOr] = _ => Right(())
 
     val policy: RetryPolicy[StringOr] =
       RetryPolicies.constantDelay[StringOr](1.second)
@@ -124,10 +113,7 @@ class SyntaxSpec extends AnyFlatSpec {
   }
 
   it should "retry until the policy chooses to give up" in new TestContext {
-    implicit val sleepForEither: Sleep[StringOr] =
-      new Sleep[StringOr] {
-        def sleep(delay: FiniteDuration): StringOr[Unit] = Right(())
-      }
+    implicit val sleepForEither: Sleep[StringOr] = _ => Right(())
 
     val policy: RetryPolicy[StringOr] =
       RetryPolicies.limitRetries[StringOr](2)
@@ -156,10 +142,7 @@ class SyntaxSpec extends AnyFlatSpec {
   behavior of "retryingOnAllErrors"
 
   it should "retry until the action succeeds" in new TestContext {
-    implicit val sleepForEither: Sleep[StringOr] =
-      new Sleep[StringOr] {
-        def sleep(delay: FiniteDuration): StringOr[Unit] = Right(())
-      }
+    implicit val sleepForEither: Sleep[StringOr] = _ => Right(())
 
     val policy: RetryPolicy[StringOr] =
       RetryPolicies.constantDelay[StringOr](1.second)
@@ -182,10 +165,7 @@ class SyntaxSpec extends AnyFlatSpec {
   }
 
   it should "retry until the policy chooses to give up" in new TestContext {
-    implicit val sleepForEither: Sleep[StringOr] =
-      new Sleep[StringOr] {
-        def sleep(delay: FiniteDuration): StringOr[Unit] = Right(())
-      }
+    implicit val sleepForEither: Sleep[StringOr] = _ => Right(())
 
     val policy: RetryPolicy[StringOr] =
       RetryPolicies.limitRetries[StringOr](2)

--- a/modules/mtl/shared/src/main/scala/retry/mtl/package.scala
+++ b/modules/mtl/shared/src/main/scala/retry/mtl/package.scala
@@ -1,7 +1,7 @@
 package retry
 
 import cats.Monad
-import cats.mtl.ApplicativeHandle
+import cats.mtl.Handle
 import cats.syntax.apply._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
@@ -21,7 +21,7 @@ package object mtl {
     )(
         implicit
         M: Monad[M],
-        AH: ApplicativeHandle[M, E],
+        AH: Handle[M, E],
         S: Sleep[M]
     ): M[A] = {
 
@@ -36,11 +36,11 @@ package object mtl {
                   S.sleep(delay) *>
                     M.pure(Left(updatedStatus)) // continue recursion
                 case NextStep.GiveUp =>
-                  AH.raise[A](error).map(Right(_)) // stop the recursion
+                  AH.raise[E, A](error).map(Right(_)) // stop the recursion
               }
             } yield result
           case Left(error) =>
-            AH.raise[A](error).map(Right(_)) // stop the recursion
+            AH.raise[E, A](error).map(Right(_)) // stop the recursion
           case Right(success) =>
             M.pure(Right(success)) // stop the recursion
         }
@@ -60,7 +60,7 @@ package object mtl {
     )(
         implicit
         M: Monad[M],
-        AH: ApplicativeHandle[M, E],
+        AH: Handle[M, E],
         S: Sleep[M]
     ): M[A] = {
       retryingOnSomeErrors[A].apply[M, E](policy, _ => true, onError)(action)

--- a/modules/mtl/shared/src/main/scala/retry/mtl/syntax/retry.scala
+++ b/modules/mtl/shared/src/main/scala/retry/mtl/syntax/retry.scala
@@ -1,7 +1,7 @@
 package retry.mtl.syntax
 
 import cats.Monad
-import cats.mtl.ApplicativeHandle
+import cats.mtl.Handle
 import retry.{RetryDetails, RetryPolicy, Sleep}
 
 trait RetrySyntax {
@@ -18,7 +18,7 @@ final class RetryingMtlErrorOps[M[_], A](action: => M[A])(
   def retryingOnAllMtlErrors[E](
       policy: RetryPolicy[M],
       onError: (E, RetryDetails) => M[Unit]
-  )(implicit S: Sleep[M], AH: ApplicativeHandle[M, E]): M[A] =
+  )(implicit S: Sleep[M], AH: Handle[M, E]): M[A] =
     retry.mtl.retryingOnAllErrors(
       policy = policy,
       onError = onError
@@ -28,7 +28,7 @@ final class RetryingMtlErrorOps[M[_], A](action: => M[A])(
       isWorthRetrying: E => Boolean,
       policy: RetryPolicy[M],
       onError: (E, RetryDetails) => M[Unit]
-  )(implicit S: Sleep[M], AH: ApplicativeHandle[M, E]): M[A] =
+  )(implicit S: Sleep[M], AH: Handle[M, E]): M[A] =
     retry.mtl.retryingOnSomeErrors(
       policy = policy,
       isWorthRetrying = isWorthRetrying,

--- a/modules/mtl/shared/src/test/scala/retry/mtl/PackageObjectSpec.scala
+++ b/modules/mtl/shared/src/test/scala/retry/mtl/PackageObjectSpec.scala
@@ -1,8 +1,6 @@
 package retry.mtl
 
 import cats.data.EitherT
-import cats.instances.either._
-import cats.mtl.instances.handle._
 import org.scalatest.flatspec.AnyFlatSpec
 import retry.{RetryDetails, RetryPolicies, Sleep}
 
@@ -13,10 +11,7 @@ class PackageObjectSpec extends AnyFlatSpec {
   type ErrorOr[A] = Either[Throwable, A]
   type F[A]       = EitherT[ErrorOr, String, A]
 
-  implicit val sleepForEitherT: Sleep[F] =
-    new Sleep[F] {
-      def sleep(delay: FiniteDuration): F[Unit] = EitherT.pure(())
-    }
+  implicit val sleepForEitherT: Sleep[F] = _ => EitherT.pure(())
 
   behavior of "retryingOnSomeErrors"
 

--- a/modules/mtl/shared/src/test/scala/retry/mtl/SyntaxSpec.scala
+++ b/modules/mtl/shared/src/test/scala/retry/mtl/SyntaxSpec.scala
@@ -2,8 +2,6 @@ package retry.mtl
 
 import cats.data.EitherT
 import cats.data.EitherT.catsDataMonadErrorFForEitherT
-import cats.instances.either._
-import cats.mtl.instances.handle._
 import org.scalatest.flatspec.AnyFlatSpec
 import retry.syntax.all._
 import retry.mtl.syntax.all._
@@ -19,10 +17,7 @@ class SyntaxSpec extends AnyFlatSpec {
   behavior of "retryingOnSomeMtlErrors"
 
   it should "retry until the action succeeds" in new TestContext {
-    implicit val sleepForEither: Sleep[F] =
-      new Sleep[F] {
-        def sleep(delay: FiniteDuration): F[Unit] = EitherT.pure(())
-      }
+    implicit val sleepForEither: Sleep[F] = _ => EitherT.pure(())
 
     val error                  = new RuntimeException("Boom!")
     val policy: RetryPolicy[F] = RetryPolicies.constantDelay[F](1.second)
@@ -48,10 +43,7 @@ class SyntaxSpec extends AnyFlatSpec {
   }
 
   it should "retry only if the error is worth retrying" in new TestContext {
-    implicit val sleepForEither: Sleep[F] =
-      new Sleep[F] {
-        def sleep(delay: FiniteDuration): F[Unit] = EitherT.pure(())
-      }
+    implicit val sleepForEither: Sleep[F] = _ => EitherT.pure(())
 
     val error                  = new RuntimeException("Boom!")
     val policy: RetryPolicy[F] = RetryPolicies.constantDelay[F](1.second)
@@ -77,10 +69,7 @@ class SyntaxSpec extends AnyFlatSpec {
   }
 
   it should "retry until the policy chooses to give up" in new TestContext {
-    implicit val sleepForEither: Sleep[F] =
-      new Sleep[F] {
-        def sleep(delay: FiniteDuration): F[Unit] = EitherT.pure(())
-      }
+    implicit val sleepForEither: Sleep[F] = _ => EitherT.pure(())
 
     val error                  = new RuntimeException("Boom!")
     val policy: RetryPolicy[F] = RetryPolicies.limitRetries[F](2)
@@ -115,10 +104,7 @@ class SyntaxSpec extends AnyFlatSpec {
   behavior of "retryingOnAllMtlErrors"
 
   it should "retry until the action succeeds" in new TestContext {
-    implicit val sleepForEither: Sleep[F] =
-      new Sleep[F] {
-        def sleep(delay: FiniteDuration): F[Unit] = EitherT.pure(())
-      }
+    implicit val sleepForEither: Sleep[F] = _ => EitherT.pure(())
 
     val error                  = new RuntimeException("Boom!")
     val policy: RetryPolicy[F] = RetryPolicies.constantDelay[F](1.second)
@@ -144,10 +130,7 @@ class SyntaxSpec extends AnyFlatSpec {
   }
 
   it should "retry until the policy chooses to give up" in new TestContext {
-    implicit val sleepForEither: Sleep[F] =
-      new Sleep[F] {
-        def sleep(delay: FiniteDuration): F[Unit] = EitherT.pure(())
-      }
+    implicit val sleepForEither: Sleep[F] = _ => EitherT.pure(())
 
     val error                  = new RuntimeException("Boom!")
     val policy: RetryPolicy[F] = RetryPolicies.limitRetries[F](2)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("com.47deg"          % "sbt-microsites"           % "1.2.1")
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt"             % "2.4.0")
 addSbtPlugin("com.geirsson"       % "sbt-ci-release"           % "1.5.3")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.33")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.2.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"            % "0.9.0")
 addSbtPlugin("com.typesafe"       % "sbt-mima-plugin"          % "0.7.0")


### PR DESCRIPTION
- Drop Scala 2.11 support
- Update scalajs to 1.2.0
- Update cats, cats-effect to 2.2.0
- Update cats-mtl to 1.0.0