### PR TITLE
Update all GH actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,28 +8,28 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: olafurpg/setup-scala@v5
+    - uses: actions/checkout@v2
+    - uses: olafurpg/setup-scala@v10
     - name: Test
       run: sbt -J-Xms4G -J-Xmx4G +test
   bincompat:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: olafurpg/setup-scala@v5
+    - uses: actions/checkout@v2
+    - uses: olafurpg/setup-scala@v10
     - name: Check binary compatibility
       run: sbt -J-Xms4G -J-Xmx4G +mimaReportBinaryIssues
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: olafurpg/setup-scala@v5
+    - uses: actions/checkout@v2
+    - uses: olafurpg/setup-scala@v10
     - name: Compile documentation
       run: sbt -J-Xms4G -J-Xmx4G docs/mdoc
   format:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: olafurpg/setup-scala@v5
+    - uses: actions/checkout@v2
+    - uses: olafurpg/setup-scala@v10
     - name: Check formatting
       run: sbt -J-Xms4G -J-Xmx4G scalafmtCheckAll scalafmtSbtCheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: olafurpg/setup-scala@v2
+      - uses: actions/checkout@v2
+      - uses: olafurpg/setup-scala@v10
       - uses: olafurpg/setup-gpg@v2
       - name: Publish
         run: sbt +test ci-release
@@ -23,8 +23,8 @@ jobs:
   publish_site:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: olafurpg/setup-scala@v5
+    - uses: actions/checkout@v2
+    - uses: olafurpg/setup-scala@v10
     - uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6


### PR DESCRIPTION
This should fix the deprecation warnings we see on the Actions page, and might fix the weird hanging step in the release workflow.