### PR TITLE
Cross-publish for Scala 3, update Scala and dependencies versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,11 @@
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
-lazy val scalaVersion213 = "2.13.3"
-lazy val scalaVersion212 = "2.12.12"
-lazy val scalaVersions   = List(scalaVersion213, scalaVersion212)
+lazy val scalaVersion212 = "2.12.14"
+lazy val scalaVersion213 = "2.13.6"
+lazy val scalaVersion3   = "3.0.1"
+lazy val scalaVersions   = List(scalaVersion212, scalaVersion213, scalaVersion3)
 
-ThisBuild / scalaVersion := scalaVersion212
+ThisBuild / scalaVersion := scalaVersion213
 
 val commonSettings = Seq(
   organization := "com.github.cb372",
@@ -38,31 +39,35 @@ val commonSettings = Seq(
 
 val moduleSettings = commonSettings ++ Seq(
   scalacOptions ++= Seq(
-    "-Xfuture",
-    "-Ywarn-dead-code",
-    "-Ywarn-unused",
     "-deprecation",
     "-encoding",
     "UTF-8",
     "-language:higherKinds",
     "-unchecked"
   ),
-  scalacOptions in (Test, compile) ++= {
+  Test / compile / scalacOptions ++= {
     if (scalaVersion.value.startsWith("2.13"))
-      Nil
-    else
-      List("-Ypartial-unification")
+      List("-Ywarn-dead-code", "-Ywarn-unused")
+    else if (scalaVersion.value.startsWith("2.12"))
+      List(
+        "-Ywarn-dead-code",
+        "-Ywarn-unused",
+        "-Ypartial-unification",
+        "-Xfuture"
+      )
+    else // scala 3.x
+      List("-language:implicitConversions")
   },
   scalafmtOnCompile := true
 )
 
-val catsVersion          = "2.5.0"
-val catsEffectVersion    = "3.1.0"
-val catsMtlVersion       = "1.2.0"
-val scalatestVersion     = "3.2.3"
-val scalaTestPlusVersion = "3.2.2.0"
-val scalacheckVersion    = "1.15.2"
-val disciplineVersion    = "2.1.1"
+val catsVersion          = "2.6.1"
+val catsEffectVersion    = "3.1.1"
+val catsMtlVersion       = "1.2.1"
+val scalatestVersion     = "3.2.9"
+val scalaTestPlusVersion = "3.2.9.0"
+val scalacheckVersion    = "1.15.4"
+val disciplineVersion    = "2.1.5"
 
 val core = crossProject(JVMPlatform, JSPlatform)
   .in(file("modules/core"))
@@ -76,7 +81,7 @@ val core = crossProject(JVMPlatform, JSPlatform)
       "org.scalatest"     %%% "scalatest"            % scalatestVersion     % Test,
       "org.scalacheck"    %%% "scalacheck"           % scalacheckVersion    % Test,
       "org.typelevel"     %%% "cats-laws"            % catsVersion          % Test,
-      "org.scalatestplus" %%% "scalacheck-1-14"      % scalaTestPlusVersion % Test,
+      "org.scalatestplus" %%% "scalacheck-1-15"      % scalaTestPlusVersion % Test,
       "org.typelevel"     %%% "discipline-scalatest" % disciplineVersion    % Test
     ),
     mimaPreviousArtifacts := Set.empty
@@ -96,7 +101,7 @@ val alleycatsRetry = crossProject(JVMPlatform, JSPlatform)
       "org.scalatest"     %%% "scalatest"            % scalatestVersion     % Test,
       "org.scalacheck"    %%% "scalacheck"           % scalacheckVersion    % Test,
       "org.typelevel"     %%% "cats-laws"            % catsVersion          % Test,
-      "org.scalatestplus" %%% "scalacheck-1-14"      % scalaTestPlusVersion % Test,
+      "org.scalatestplus" %%% "scalacheck-1-15"      % scalaTestPlusVersion % Test,
       "org.typelevel"     %%% "discipline-scalatest" % disciplineVersion    % Test
     ),
     mimaPreviousArtifacts := Set.empty
@@ -131,7 +136,7 @@ val docs = project
     scalacOptions -= "-Ywarn-unused",
     scalacOptions += "-Ydelambdafy:inline",
     addCompilerPlugin(
-      "org.typelevel" %% "kind-projector" % "0.11.0" cross CrossVersion.full
+      "org.typelevel" %% "kind-projector" % "0.13.0" cross CrossVersion.full
     ),
     crossScalaVersions := Nil,
     buildInfoPackage := "retry",
@@ -147,7 +152,7 @@ val docs = project
     micrositeGitterChannel := true,
     micrositeGitterChannelUrl := "typelevel/cats-retry",
     micrositeTwitterCreator := "@cbirchall",
-    mdocIn := (sourceDirectory in Compile).value / "mdoc",
+    mdocIn := (Compile / sourceDirectory).value / "mdoc",
     micrositeShareOnSocial := true,
     micrositePushSiteWith := GitHub4s,
     micrositeGithubToken := sys.env.get("GITHUB_TOKEN")

--- a/modules/core/shared/src/test/scala/retry/PackageObjectSpec.scala
+++ b/modules/core/shared/src/test/scala/retry/PackageObjectSpec.scala
@@ -1,6 +1,6 @@
 package retry
 
-import cats.Id
+import cats.{Id, catsInstancesForId}
 import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.collection.mutable.ArrayBuffer

--- a/modules/core/shared/src/test/scala/retry/RetryPolicyLawsSpec.scala
+++ b/modules/core/shared/src/test/scala/retry/RetryPolicyLawsSpec.scala
@@ -1,7 +1,7 @@
 package retry
 
 import cats.instances.all._
-import cats.{Eq, Monoid, Id}
+import cats.{Eq, Monoid, Id, catsInstancesForId}
 import cats.kernel.laws.discipline.BoundedSemilatticeTests
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import org.scalatest.funsuite.AnyFunSuite
@@ -30,7 +30,7 @@ class RetryPolicyLawsSpec
 
   implicit val arbitraryPolicyDecision: Arbitrary[PolicyDecision] =
     Arbitrary(for {
-      delay <- Gen.choose(0, Long.MaxValue).map(Duration.fromNanos)
+      delay <- Gen.choose(0L, Long.MaxValue).map(Duration.fromNanos)
       decision <- Gen
         .oneOf(PolicyDecision.GiveUp, PolicyDecision.DelayAndRetry(delay))
     } yield decision)

--- a/modules/core/shared/src/test/scala/retry/RetryPolicySpec.scala
+++ b/modules/core/shared/src/test/scala/retry/RetryPolicySpec.scala
@@ -1,6 +1,6 @@
 package retry
 
-import cats.Id
+import cats.{Id, catsInstancesForId}
 import cats.syntax.semigroup._
 import org.scalatest.flatspec.AnyFlatSpec
 

--- a/modules/core/shared/src/test/scala/retry/SyntaxSpec.scala
+++ b/modules/core/shared/src/test/scala/retry/SyntaxSpec.scala
@@ -1,6 +1,6 @@
 package retry
 
-import cats.Id
+import cats.{Id, catsInstancesForId}
 import org.scalatest.flatspec.AnyFlatSpec
 import retry.syntax.all._
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.6
+sbt.version=1.5.5


### PR DESCRIPTION
This PR is hugely inspired by the excellent job done in #291 and #294, and tries to address #249.
I think it's now obvious that indeed the answer to the first question there was yes, it's possible to cross-build for 2.12, 2.13 and 3 at the same time. No code changes were required, apart from an added import and a trivial rewrite in some tests (catsInstancesForId, parenthesis around lambda arguments).

I didn't try to change the API to be more ergonomic (taking advantage of Scala 3 inference) given that 3.0.0 was already released, nor I tried to use new Scala 3 features, even if that _should_ be possible by using [version-specific source directory](https://www.scala-sbt.org/1.x/docs/Cross-Build.html#Scala-version+specific+source+directory). So to answer the last question, yes it should be possible to start using those features and still being able to cross-publish for Scala 2.12, even if that would require maintaining separate sources for different Scala versions obviously.

On another topic, I didn't try to port tests to MUnit either, because Scalatest and Scalacheck are now published for Scala 3, so it wasn't strictly necessary. Moreover, I didn't want to steal too much from #291.

This should also unblock publishing libraries which depend on cats-retry for Scala 3 (e.g. cats-saga https://github.com/VladKopanev/cats-saga/issues/100)