### PR TITLE
Add a v3 -> v4 migration guide

### DIFF
--- a/modules/core/shared/src/test/scala/retry/CombinatorsSuite.scala
+++ b/modules/core/shared/src/test/scala/retry/CombinatorsSuite.scala
@@ -43,10 +43,7 @@ class CombinatorsSuite extends CatsEffectSuite:
 
     // AND a result handler that does no adaptation and treats the 4th result as a success
     def mkHandler(fixture: Fixture[String]): ValueHandler[IO, String] =
-      (result: String, retryDetails: RetryDetails) =>
-        fixture
-          .updateState(result, retryDetails)
-          .as(if result.toInt > 3 then Stop else Continue)
+      ResultHandler.retryUntilSuccessful(_.toInt > 3, log = fixture.updateState)
 
     // AND an action that returns the attempt count as a string
     def mkAction(fixture: Fixture[String]): IO[String] =
@@ -80,10 +77,7 @@ class CombinatorsSuite extends CatsEffectSuite:
 
     // AND a result handler that does no adaptation and treats the 4th result as a success
     def mkHandler(fixture: Fixture[String]): ValueHandler[IO, String] =
-      (result: String, retryDetails: RetryDetails) =>
-        fixture
-          .updateState(result, retryDetails)
-          .as(if result.toInt > 3 then Stop else Continue)
+      ResultHandler.retryUntilSuccessful(_.toInt > 3, log = fixture.updateState)
 
     // AND an action that returns the attempt count as a string
     def mkAction(fixture: Fixture[String]): IO[String] =
@@ -166,10 +160,7 @@ class CombinatorsSuite extends CatsEffectSuite:
 
     // AND a result handler that will retry > 10k times
     def mkHandler(fixture: Fixture[String]): ValueHandler[IO, String] =
-      (result: String, retryDetails: RetryDetails) =>
-        fixture
-          .updateState(result, retryDetails)
-          .as(if result.toInt > 20_000 then Stop else Continue)
+      ResultHandler.retryUntilSuccessful(_.toInt > 20_000, log = fixture.updateState)
 
     // AND an action that returns the attempt count as a string
     def mkAction(fixture: Fixture[String]): IO[String] =
@@ -197,10 +188,7 @@ class CombinatorsSuite extends CatsEffectSuite:
 
     // AND a result handler that retries on all errors
     def mkHandler(fixture: Fixture[Throwable]): ErrorHandler[IO, String] =
-      (error: Throwable, retryDetails: RetryDetails) =>
-        fixture
-          .updateState(error, retryDetails)
-          .as(Continue)
+      ResultHandler.retryOnAllErrors(log = fixture.updateState)
 
     // AND an action that raises an error twice and then succeeds
     def mkAction(fixture: Fixture[Throwable]): IO[String] =
@@ -238,10 +226,7 @@ class CombinatorsSuite extends CatsEffectSuite:
 
     // AND a result handler that retries on all errors
     def mkHandler(fixture: Fixture[Throwable]): ErrorHandler[IO, String] =
-      (error: Throwable, retryDetails: RetryDetails) =>
-        fixture
-          .updateState(error, retryDetails)
-          .as(Continue)
+      ResultHandler.retryOnAllErrors(log = fixture.updateState)
 
     // AND an action that always raises an error
     def mkAction(fixture: Fixture[Throwable]): IO[String] =
@@ -276,14 +261,7 @@ class CombinatorsSuite extends CatsEffectSuite:
 
     // AND a result handler that retries on some errors but gives up on others
     def mkHandler(fixture: Fixture[Throwable]): ErrorHandler[IO, String] =
-      (error: Throwable, retryDetails: RetryDetails) =>
-        fixture
-          .updateState(error, retryDetails)
-          .as {
-            error match
-              case `oneMoreTimeException` => Continue
-              case _                      => Stop
-          }
+      ResultHandler.retryOnSomeErrors(_ == oneMoreTimeException, log = fixture.updateState)
 
     // AND an action that raises a retryable error followed by a non-retryable error
     def mkAction(fixture: Fixture[Throwable]): IO[String] =
@@ -366,10 +344,7 @@ class CombinatorsSuite extends CatsEffectSuite:
 
     // AND a result handler that will always retry
     def mkHandler(fixture: Fixture[Throwable]): ErrorHandler[IO, String] =
-      (error: Throwable, retryDetails: RetryDetails) =>
-        fixture
-          .updateState(error, retryDetails)
-          .as(Continue)
+      ResultHandler.retryOnAllErrors(log = fixture.updateState)
 
     // AND an action that always raises an error
     def mkAction(fixture: Fixture[Throwable]): IO[String] =

--- a/modules/core/shared/src/test/scala/retry/SyntaxSuite.scala
+++ b/modules/core/shared/src/test/scala/retry/SyntaxSuite.scala
@@ -43,10 +43,7 @@ class SyntaxSuite extends CatsEffectSuite:
 
     // AND a result handler that does no adaptation and treats the 4th result as a success
     def mkHandler(fixture: Fixture[String]): ValueHandler[IO, String] =
-      (result: String, retryDetails: RetryDetails) =>
-        fixture
-          .updateState(result, retryDetails)
-          .as(if result.toInt > 3 then Stop else Continue)
+      ResultHandler.retryUntilSuccessful(_.toInt > 3, log = fixture.updateState)
 
     // AND an action that returns the attempt count as a string
     def mkAction(fixture: Fixture[String]): IO[String] =
@@ -80,10 +77,7 @@ class SyntaxSuite extends CatsEffectSuite:
 
     // AND a result handler that retries on all errors
     def mkHandler(fixture: Fixture[Throwable]): ErrorHandler[IO, String] =
-      (error: Throwable, retryDetails: RetryDetails) =>
-        fixture
-          .updateState(error, retryDetails)
-          .as(Continue)
+      ResultHandler.retryOnAllErrors(log = fixture.updateState)
 
     // AND an action that raises an error twice and then succeeds
     def mkAction(fixture: Fixture[Throwable]): IO[String] =

--- a/modules/docs/src/main/mdoc/docs/combinators.md
+++ b/modules/docs/src/main/mdoc/docs/combinators.md
@@ -82,6 +82,12 @@ The return value is one of:
   `Left(...)` to indicate failure
 - an error raised in `F`, if either the action or the value handler raised an error
 
+### Semantics
+
+[![](https://mermaid.ink/img/pako:eNp1UstuwjAQ_BXLJ5DgB3KohAptDz1URFya5LCyN8SSY0d-0EZJ_r2ODRREm4N3Z_Y163igTHOkGa2l_mINGEfe96Ui4ctdQIsimmpJ1usnsvtG5h2m-BnMgXEPwqIlaIw2I9nNZlFEMnHV8q6muNQCc0KrKvVA542y5ATS40jeQHGJZnjWynrpSJPwlBqdo_8Nf0zKne5GknvG0NqgLQ4jNuHayzT2ovO2MghwQs2SPrQUrL8q6iL8Q9CGQ-dGEk1x6Dj8bpqSYyTeaGqZ2OTHDq_ihIeg9wWE9AaveuuAkd9rvSnbooR-o3jINv1IIkxJ0X34h_NBV7RF04Lg4RUMM1NS12CLJc2Cy7GGsGxJSzWFVPBO571iNHPG44oa7Y8NzWqQNiAfd90KOBpor2wH6lPrC55-AD8B1nA?type=png)](https://mermaid.live/edit#pako:eNp1UstuwjAQ_BXLJ5DgB3KohAptDz1URFya5LCyN8SSY0d-0EZJ_r2ODRREm4N3Z_Y163igTHOkGa2l_mINGEfe96Ui4ctdQIsimmpJ1usnsvtG5h2m-BnMgXEPwqIlaIw2I9nNZlFEMnHV8q6muNQCc0KrKvVA542y5ATS40jeQHGJZnjWynrpSJPwlBqdo_8Nf0zKne5GknvG0NqgLQ4jNuHayzT2ovO2MghwQs2SPrQUrL8q6iL8Q9CGQ-dGEk1x6Dj8bpqSYyTeaGqZ2OTHDq_ihIeg9wWE9AaveuuAkd9rvSnbooR-o3jINv1IIkxJ0X34h_NBV7RF04Lg4RUMM1NS12CLJc2Cy7GGsGxJSzWFVPBO571iNHPG44oa7Y8NzWqQNiAfd90KOBpor2wH6lPrC55-AD8B1nA)
+
+### Example
+
 For example, let's keep rolling a die until we get a six, using `IO`.
 
 ```scala mdoc:silent
@@ -155,6 +161,12 @@ The return value is either:
     - the action raised an error that the error handler judged to be unrecoverable
     - the action repeatedly raised errors and we ran out of retries
     - the error handler raised an error
+
+### Semantics
+
+[![](https://mermaid.ink/img/pako:eNptUU1vwjAM_StRTiDBH-hhEhpoO-wwUXFZy8FKXBopTap8sFWU_740BgYaudjP7_nFTk5cWIm84I2236IFF9jHtjYsnTIkNKty2M_ZcvnCNj8oYkDiL2Aixi2G6IxnR9ARR1ZGIdD7WUV15gk3UZNiP3-wqK5WIIKyZk-WoDx6hs5ZN7J3MFKjO71a46MOrCV8Jp8L-6RvM4U0x1Sk2vXu-54y2P6i_U-mK4My01qfVisx3GboM3wywkpCH0aWQ7XrJfytRuLM5BclS6pSnh3e1BF3jyPdsWvUMKyMTK_rhpFlSKKc3n8VX_AOXQdKpj8-TaKahxY7rHmRUokNpFVqXptzkkIMthyM4EVwERfc2XhoedGA9gnFvMlawcFBd6v2YL6sveLzL-oSyzM?type=png)](https://mermaid.live/edit#pako:eNptUU1vwjAM_StRTiDBH-hhEhpoO-wwUXFZy8FKXBopTap8sFWU_740BgYaudjP7_nFTk5cWIm84I2236IFF9jHtjYsnTIkNKty2M_ZcvnCNj8oYkDiL2Aixi2G6IxnR9ARR1ZGIdD7WUV15gk3UZNiP3-wqK5WIIKyZk-WoDx6hs5ZN7J3MFKjO71a46MOrCV8Jp8L-6RvM4U0x1Sk2vXu-54y2P6i_U-mK4My01qfVisx3GboM3wywkpCH0aWQ7XrJfytRuLM5BclS6pSnh3e1BF3jyPdsWvUMKyMTK_rhpFlSKKc3n8VX_AOXQdKpj8-TaKahxY7rHmRUokNpFVqXptzkkIMthyM4EVwERfc2XhoedGA9gnFvMlawcFBd6v2YL6sveLzL-oSyzM)
+
+### Example
 
 For example, let's make a request for a cat gif using our flaky HTTP client,
 retrying only if we get an `IOException`.
@@ -230,6 +242,12 @@ The return value is one of:
     - the action raised an error that the error handler judged to be unrecoverable
     - the action repeatedly raised errors and we ran out of retries
     - the error handler raised an error
+
+### Semantics
+
+[![](https://mermaid.ink/img/pako:eNqVU8tugzAQ_BXLp0RKfoBDpahJ20OlVkHpoZCDhZdgydjIj7Qo5N9rbIIgCZHKxcx4ZtfL4BPOJAUc4ZzLn6wgyqD3bSqQe2Lj0Czxy36OlssntPmFzBoI-x1oN5otGKuERkfCLTToq13eiKAc1OlZCm25QUXA5-AeSnyJ2MiqQbHNMtB6loSKSAecWx5q7-cTdtfFMNE2_5ScZfWHeCGMWwV9_8rzU-1XlFSmQX7pvcmuosSNSDLDpNgH61jiv8tVy6C7In2XV3aEnRuz4_oxc4eBjke8518DJ_VKUGdTdYM8nBhoS5gGjUApqRq0aRfXriUDd2nTxZhc4uxmnarxONWh5H-nuDaG38HTE4rbxL3kft437nHefvtR2l4wynpwtBE1yvmhaDpM_zq8cXiBS1AlYdRd1VMrSrEpoIQUR-6VQk7cyClOxdlJiTUyrkWGI6MsLLCS9lDgKCdcO2T9lGtGDoqUPVsR8S3lBZ__AAneb50?type=png)](https://mermaid.live/edit#pako:eNqVU8tugzAQ_BXLp0RKfoBDpahJ20OlVkHpoZCDhZdgydjIj7Qo5N9rbIIgCZHKxcx4ZtfL4BPOJAUc4ZzLn6wgyqD3bSqQe2Lj0Czxy36OlssntPmFzBoI-x1oN5otGKuERkfCLTToq13eiKAc1OlZCm25QUXA5-AeSnyJ2MiqQbHNMtB6loSKSAecWx5q7-cTdtfFMNE2_5ScZfWHeCGMWwV9_8rzU-1XlFSmQX7pvcmuosSNSDLDpNgH61jiv8tVy6C7In2XV3aEnRuz4_oxc4eBjke8518DJ_VKUGdTdYM8nBhoS5gGjUApqRq0aRfXriUDd2nTxZhc4uxmnarxONWh5H-nuDaG38HTE4rbxL3kft437nHefvtR2l4wynpwtBE1yvmhaDpM_zq8cXiBS1AlYdRd1VMrSrEpoIQUR-6VQk7cyClOxdlJiTUyrkWGI6MsLLCS9lDgKCdcO2T9lGtGDoqUPVsR8S3lBZ__AAneb50)
+
+### Example
 
 For example, let's make a request to an API to retrieve details for a record, which we will only retry if:
 

--- a/modules/docs/src/main/mdoc/docs/combinators.md
+++ b/modules/docs/src/main/mdoc/docs/combinators.md
@@ -243,6 +243,32 @@ The return value is one of:
     - the action repeatedly raised errors and we ran out of retries
     - the error handler raised an error
 
+### `ErrorOrValueHandler`
+
+Note that the behaviour of the `ErrorOrValueHandler` is quite subtle.
+
+The interpretation of its decision (a `HandlerDecision`) depends on whether the
+action returned a value or raised an error
+
+If the action returned a value, the handler will be given a `Right(someValue)`
+to inspect.
+* If the handler decides the result of the action was successful, it should
+  return `Stop`, meaning there is no need to keep retrying. cats-retry will stop
+  retrying, and return the successful result.
+* On the other hand, if the handler decides that action was *not* successful, it
+  should return `Continue`, meaning the action has not succeeded yet so we should
+  keep retrying. cats-retry will then consult the retry policy. If the policy
+  agrees to keep retrying, cats-retry will do so. Otherwise it will return the
+  failed value.
+
+If the action raised an error, the handler will be given a `Left(someThrowable)`
+to inspect.
+* If the handler decides the error is worth retrying, it should return
+  `Continue`. cats-retry will then consult the retry policy. If the policy agrees
+  to keep retrying, cats-retry will do so. Otherwise it will re-raise the error.
+* If the handler decides the error is *not* worth retrying, it should return
+  `Stop`. cats-retry will re-raise the error.
+
 ### Semantics
 
 [![](https://mermaid.ink/img/pako:eNqVU8tugzAQ_BXLp0RKfoBDpahJ20OlVkHpoZCDhZdgydjIj7Qo5N9rbIIgCZHKxcx4ZtfL4BPOJAUc4ZzLn6wgyqD3bSqQe2Lj0Czxy36OlssntPmFzBoI-x1oN5otGKuERkfCLTToq13eiKAc1OlZCm25QUXA5-AeSnyJ2MiqQbHNMtB6loSKSAecWx5q7-cTdtfFMNE2_5ScZfWHeCGMWwV9_8rzU-1XlFSmQX7pvcmuosSNSDLDpNgH61jiv8tVy6C7In2XV3aEnRuz4_oxc4eBjke8518DJ_VKUGdTdYM8nBhoS5gGjUApqRq0aRfXriUDd2nTxZhc4uxmnarxONWh5H-nuDaG38HTE4rbxL3kft437nHefvtR2l4wynpwtBE1yvmhaDpM_zq8cXiBS1AlYdRd1VMrSrEpoIQUR-6VQk7cyClOxdlJiTUyrkWGI6MsLLCS9lDgKCdcO2T9lGtGDoqUPVsR8S3lBZ__AAneb50?type=png)](https://mermaid.live/edit#pako:eNqVU8tugzAQ_BXLp0RKfoBDpahJ20OlVkHpoZCDhZdgydjIj7Qo5N9rbIIgCZHKxcx4ZtfL4BPOJAUc4ZzLn6wgyqD3bSqQe2Lj0Czxy36OlssntPmFzBoI-x1oN5otGKuERkfCLTToq13eiKAc1OlZCm25QUXA5-AeSnyJ2MiqQbHNMtB6loSKSAecWx5q7-cTdtfFMNE2_5ScZfWHeCGMWwV9_8rzU-1XlFSmQX7pvcmuosSNSDLDpNgH61jiv8tVy6C7In2XV3aEnRuz4_oxc4eBjke8518DJ_VKUGdTdYM8nBhoS5gGjUApqRq0aRfXriUDd2nTxZhc4uxmnarxONWh5H-nuDaG38HTE4rbxL3kft437nHefvtR2l4wynpwtBE1yvmhaDpM_zq8cXiBS1AlYdRd1VMrSrEpoIQUR-6VQk7cyClOxdlJiTUyrkWGI6MsLLCS9lDgKCdcO2T9lGtGDoqUPVsR8S3lBZ__AAneb50)

--- a/modules/docs/src/main/mdoc/docs/index.md
+++ b/modules/docs/src/main/mdoc/docs/index.md
@@ -43,7 +43,7 @@ println(
 (Note: if you're using Scala.js, you'll need a `%%%` instead of `%%`.)
 
 First we'll need a retry policy. We'll keep it simple: retry up to 5 times, with
-no delay between attempts. (See the [retry policies page](policies.html) for
+no delay between attempts. (See the [retry policies page](./policies) for
 information on more powerful policies).
 
 ```scala mdoc:silent
@@ -96,6 +96,6 @@ logMessages.foreach(println)
 
 Next steps:
 
-- Learn about the other available [combinators](combinators.html)
-- Learn about the [MTL combinators](mtl-combinators.html)
-- Learn more about [retry policies](policies.html)
+- Learn about the other available [combinators](./combinators)
+- Learn about the [MTL combinators](./mtl-combinators)
+- Learn more about [retry policies](./policies)

--- a/modules/docs/src/main/mdoc/docs/migration.md
+++ b/modules/docs/src/main/mdoc/docs/migration.md
@@ -1,0 +1,300 @@
+---
+layout: docs
+title: Migration Guide
+---
+
+# cats-retry v3 -> v4 Migration Guide
+
+The major changes in v4 are as follows:
+* **Scala 3**. The library is now published for Scala 3 only.
+* **Cats Effect**. The library is now more strongly coupled to Cats Effect.
+* **Adaption**. cats-retry now supports adaptation in the face of errors or failures.
+* **API redesign**. The API has been completely rewritten to provide more power
+and flexibility with fewer combinators.
+
+The following migration guide will cover each of those topics.
+
+## Scala 3
+
+cats-retry v4 is only published for Scala 3.3.x. It will work with Scala 3.3.x
+or newer.
+
+It *might* work with Scala 2.13, but it has not been tested.
+
+If you use Scala 2.13, please stick with cats-retry v3.
+
+## Cats Effect
+
+In v4 we decided to embrace Cats Effect more closely in order to simplify the
+library. That means:
+* the `cats-retry-alleycats` module is gone
+* the `Sleep` type class is gone; we use CE `Temporal` directly
+* Instead of an abstract error type `E`, the error type is now `Throwable`
+* your effect monad will need to be Cats Effect `IO` or something similar
+(anything with a `Temporal` instance)
+
+If you use the `alleycats` module, please stick with cats-retry v3.
+
+## Adaptation
+
+The biggest new feature in v4 is support for adaptation.
+
+Please see the [adaptation docs](./adaptation) for an explanation and a worked example.
+
+## API redesign
+
+There are now fewer combinators, and hooks such as `wasSuccessful` or
+`isWorthRetrying` have been replaced with a more powerful concept known as a
+"result handler".
+
+For each of the combinators in cats-retry v3, we will show how to update your
+code when upgrading to v4.
+
+### `retryingM`
+
+This alias for `retryingOnFailures` was deprecated and has been removed.
+
+Please follow the `retryingOnFailures` migration guide.
+
+### `retryingOnFailures`
+
+Old:
+
+```scala
+def retryingOnFailures[F[_]](
+    policy: RetryPolicy[F],
+    wasSuccessful: A => F[Boolean],
+    onFailure: (A, RetryDetails) => F[Unit]
+)(
+    action: => F[A]
+): F[A]
+```
+
+New:
+
+```scala
+def retryingOnFailures[F[_]: Temporal, A](
+    action: F[A]
+)(
+    policy: RetryPolicy[F],
+    valueHandler: ValueHandler[F, A]
+): F[Either[A, A]]
+```
+
+The action is now passed as the first argument, not the last.
+
+The policy can be used without any changes.
+
+`wasSuccessful` and `onFailure` have been replaced by `valueHandler`. This is a
+function that takes the action's result and the retry details, does any
+necessary logging, and decides what to do next.
+
+If your `wasSuccessful` is a simple predicate lifted to `F` using `pure`, then
+there is a helper you can use to maintain the existing behaviour:
+
+```scala
+retryingOnFailures(action)(
+  policy,
+  valueHandler = ResultHandler.retryUntilSuccessful(predicate, log = doSomeLogging)
+)
+```
+
+Note that `doSomeLogging` will be invoked after every attempt, not only on
+failure, so it's not exactly the same as the old `onFailure` hook.
+
+The result is now `F[Either[A, A]]`. This is to indicate whether the returned
+value was a success or a failure. If the operation failed, but we gave up
+because we exhausted our retries, then the result will be wrapped in a `Left`.
+If it's a successful result, it will be a `Right`.
+
+### `retryingOnSomeErrors`
+
+Old:
+
+```scala
+def retryingOnSomeErrors[F[_], E](
+    policy: RetryPolicy[F],
+    isWorthRetrying: E => F[Boolean],
+    onError: (E, RetryDetails) => F[Unit]
+)(
+    action: => F[A]
+): F[A]
+```
+
+New:
+
+```scala
+def retryingOnErrors[F[_], A](
+    action: F[A]
+)(
+    policy: RetryPolicy[F],
+    errorHandler: ErrorHandler[F, A]
+): F[A]
+```
+
+The error type is now hardcoded to `Throwable`, so the `E` type parameter has
+been removed.
+
+The action is now passed as the first argument, not the last.
+
+The policy can be used without any changes.
+
+`isWorthRetrying` and `onError` have been replaced by `errorHandler`. This is a
+function that takes the raised error and the retry details, does any necessary
+logging, and decides what to do next.
+
+If your `isWorthRetrying` is a simple predicate lifted to `F` using `pure`, then
+there is a helper you can use to maintain the existing behaviour:
+
+```scala
+retryingOnErrors(action)(
+  policy,
+  errorHandler = ResultHandler.retryOnSomeErrors(predicate, log = doSomeLogging)
+)
+```
+
+Note that `doSomeLogging` will be invoked every time an error is raised, not
+only on errors that are worth retrying, so it's not exactly the same as the old
+`onError` hook.
+
+### `retryingOnAllErrors`
+
+Old:
+
+```scala
+def retryingOnAllErrors[F[_], E](
+    policy: RetryPolicy[F],
+    onError: (E, RetryDetails) => F[Unit]
+)(
+    action: => F[A]
+): F[A]
+```
+
+New:
+
+```scala
+def retryingOnErrors[F[_], A](
+    action: F[A]
+)(
+    policy: RetryPolicy[F],
+    errorHandler: ErrorHandler[F, A]
+): F[A]
+```
+
+The error type is now hardcoded to `Throwable`, so the `E` type parameter has
+been removed.
+
+The action is now passed as the first argument, not the last.
+
+The policy can be used without any changes.
+
+`onError` has been replaced by `errorHandler`. This is a function that takes the
+raised error and the retry details, does any necessary logging, and decides what
+to do next.
+
+There is a helper you can use to maintain the existing behaviour:
+
+```scala
+retryingOnErrors(action)(
+  policy,
+  errorHandler = ResultHandler.retryOnAllErrors(log = doSomeLogging)
+)
+```
+
+Note that `doSomeLogging` will be invoked every time an error is raised, so it
+is basically the same as the old `onError` hook.
+
+### `retryingOnFailuresAndSomeErrors`
+
+Old:
+
+```scala
+def retryingOnFailuresAndSomeErrors[F[_], E](
+    policy: RetryPolicy[F],
+    wasSuccessful: A => F[Boolean],
+    isWorthRetrying: E => F[Boolean],
+    onFailure: (A, RetryDetails) => F[Unit],
+    onError: (F, RetryDetails) => F[Unit]
+)(
+    action: => F[A]
+): F[A]
+```
+
+New:
+
+```scala
+def retryingOnFailuresAndErrors[F[_], A](
+    action: F[A]
+)(
+    policy: RetryPolicy[F],
+    errorOrValueHandler: ErrorOrValueHandler[F, A]
+): F[Either[A, A]]
+```
+
+The error type is now hardcoded to `Throwable`, so the `E` type parameter has
+been removed.
+
+The action is now passed as the first argument, not the last.
+
+The policy can be used without any changes.
+
+`wasSuccessful`, `isWorthRetrying`, `onFailure` and `onError` have been replaced
+by a single `errorOrValueHandler`. This is a function that takes the action's
+result or the error that was raised, plus the retry details, does any necessary
+logging, and decides what to do next.
+
+See the [`retryingOnFailuresAndErrors`
+docs](./combinators#retryingonfailuresanderrors) for more details on how to
+write an `ErrorOrValueHandler`.
+
+The result is now `F[Either[A, A]]`. This is to indicate whether the returned
+value was a success or a failure. If the operation failed, but we gave up
+because we exhausted our retries, then the result will be wrapped in a `Left`.
+If it's a successful result, it will be a `Right`.
+
+### `retryingOnFailuresAndAllErrors`
+
+Old:
+
+```scala
+def retryingOnFailuresAndAllErrors[F[_], E](
+    policy: RetryPolicy[F],
+    wasSuccessful: A => F[Boolean],
+    onFailure: (A, RetryDetails) => F[Unit],
+    onError: (F, RetryDetails) => F[Unit]
+)(
+    action: => F[A]
+): F[A]
+```
+
+New:
+
+```scala
+def retryingOnFailuresAndErrors[F[_], A](
+    action: F[A]
+)(
+    policy: RetryPolicy[F],
+    errorOrValueHandler: ErrorOrValueHandler[F, A]
+): F[Either[A, A]]
+```
+
+The error type is now hardcoded to `Throwable`, so the `E` type parameter has
+been removed.
+
+The action is now passed as the first argument, not the last.
+
+The policy can be used without any changes.
+
+`wasSuccessful`, `onFailure` and `onError` have been replaced by a single
+`errorOrValueHandler`. This is a function that takes the action's result or the
+error that was raised, plus the retry details, does any necessary logging, and
+decides what to do next.
+
+See the [`retryingOnFailuresAndErrors`
+docs](./combinators#retryingonfailuresanderrors) for more details on how to
+write an `ErrorOrValueHandler`.
+
+The result is now `F[Either[A, A]]`. This is to indicate whether the returned
+value was a success or a failure. If the operation failed, but we gave up
+because we exhausted our retries, then the result will be wrapped in a `Left`.
+If it's a successful result, it will be a `Right`.

--- a/modules/docs/src/main/resources/microsite/data/menu.yml
+++ b/modules/docs/src/main/resources/microsite/data/menu.yml
@@ -1,11 +1,13 @@
 options:
   - title: Getting started
-    url: docs/index.html
+    url: docs/
   - title: Combinators
-    url: docs/combinators.html
+    url: docs/combinators
   - title: MTL Combinators
-    url: docs/mtl-combinators.html
+    url: docs/mtl-combinators
   - title: Retry policies
-    url: docs/policies.html
+    url: docs/policies
   - title: Adaptation
-    url: docs/adaptation.html
+    url: docs/adaptation
+  - title: v3 -> v4 Migration
+    url: docs/migration


### PR DESCRIPTION
Closes #531 

* Add flowcharts to explain the logic for each combinator
* Write a migration guide to help people migrate from v3
* Add a helper method for building an error handler that retries on some errors
* Use the helper methods where possible in the unit tests