### PR TITLE
Dynamic retry policies

### DIFF
--- a/modules/core/shared/src/main/scala/retry/RetryPolicies.scala
+++ b/modules/core/shared/src/main/scala/retry/RetryPolicies.scala
@@ -146,4 +146,16 @@ object RetryPolicies:
       decideNextRetry,
       show"limitRetriesByCumulativeDelay(threshold=$threshold, $policy)"
     )
+
+  /** Build a dynamic retry policy that chooses the retry policy based on the result of the last attempt
+    */
+  def dynamic[F[_], Res](f: Res => RetryPolicy[F, Res]): RetryPolicy[F, Res] =
+    def decideNextRetry(actionResult: Res, status: RetryStatus): F[PolicyDecision] =
+      val policy = f(actionResult)
+      policy.decideNextRetry(actionResult, status)
+
+    RetryPolicy.withShow[F, Res](
+      decideNextRetry,
+      show"dynamic(<function>)"
+    )
 end RetryPolicies

--- a/modules/core/shared/src/main/scala/retry/RetryPolicies.scala
+++ b/modules/core/shared/src/main/scala/retry/RetryPolicies.scala
@@ -32,14 +32,14 @@ object RetryPolicies:
 
   /** Don't retry at all and always give up. Only really useful for combining with other policies.
     */
-  def alwaysGiveUp[F[_]: Applicative]: RetryPolicy[F] =
-    RetryPolicy.liftWithShow(Function.const(GiveUp), "alwaysGiveUp")
+  def alwaysGiveUp[F[_]: Applicative]: RetryPolicy[F, Any] =
+    RetryPolicy.liftWithShow((_, _) => GiveUp, "alwaysGiveUp")
 
   /** Delay by a constant amount before each retry. Never give up.
     */
-  def constantDelay[F[_]: Applicative](delay: FiniteDuration): RetryPolicy[F] =
+  def constantDelay[F[_]: Applicative](delay: FiniteDuration): RetryPolicy[F, Any] =
     RetryPolicy.liftWithShow(
-      Function.const(DelayAndRetry(delay)),
+      (_, _) => DelayAndRetry(delay),
       show"constantDelay($delay)"
     )
 
@@ -47,9 +47,9 @@ object RetryPolicies:
     */
   def exponentialBackoff[F[_]: Applicative](
       baseDelay: FiniteDuration
-  ): RetryPolicy[F] =
+  ): RetryPolicy[F, Any] =
     RetryPolicy.liftWithShow(
-      { status =>
+      { (_, status) =>
         val delay =
           safeMultiply(
             baseDelay,
@@ -62,9 +62,9 @@ object RetryPolicies:
 
   /** Retry without delay, giving up after the given number of retries.
     */
-  def limitRetries[F[_]: Applicative](maxRetries: Int): RetryPolicy[F] =
+  def limitRetries[F[_]: Applicative](maxRetries: Int): RetryPolicy[F, Any] =
     RetryPolicy.liftWithShow(
-      { status =>
+      { (_, status) =>
         if status.retriesSoFar >= maxRetries then GiveUp
         else DelayAndRetry(Duration.Zero)
       },
@@ -76,11 +76,9 @@ object RetryPolicies:
     * e.g. if `baseDelay` is 10 milliseconds, the delays before each retry will be 10 ms, 10 ms, 20 ms, 30ms,
     * 50ms, 80ms, 130ms, ...
     */
-  def fibonacciBackoff[F[_]: Applicative](
-      baseDelay: FiniteDuration
-  ): RetryPolicy[F] =
+  def fibonacciBackoff[F[_]: Applicative](baseDelay: FiniteDuration): RetryPolicy[F, Any] =
     RetryPolicy.liftWithShow(
-      { status =>
+      { (_, status) =>
         val delay =
           safeMultiply(baseDelay, Fibonacci.fibonacci(status.retriesSoFar + 1))
         DelayAndRetry(delay)
@@ -91,9 +89,9 @@ object RetryPolicies:
   /** "Full jitter" backoff algorithm. See
     * https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
     */
-  def fullJitter[F[_]: Applicative](baseDelay: FiniteDuration): RetryPolicy[F] =
+  def fullJitter[F[_]: Applicative](baseDelay: FiniteDuration): RetryPolicy[F, Any] =
     RetryPolicy.liftWithShow(
-      { status =>
+      { (_, status) =>
         val e          = Math.pow(2.0, status.retriesSoFar.toDouble).toLong
         val maxDelay   = safeMultiply(baseDelay, e)
         val delayNanos = (maxDelay.toNanos * Random.nextDouble()).toLong
@@ -104,28 +102,28 @@ object RetryPolicies:
 
   /** Set an upper bound on any individual delay produced by the given policy.
     */
-  def capDelay[F[_]: Applicative](
+  def capDelay[F[_]: Applicative, Res](
       cap: FiniteDuration,
-      policy: RetryPolicy[F]
-  ): RetryPolicy[F] =
+      policy: RetryPolicy[F, Res]
+  ): RetryPolicy[F, Res] =
     policy.meet(constantDelay(cap))
 
   /** Add an upper bound to a policy such that once the given time-delay amount <b>per try</b> has been
     * reached or exceeded, the policy will stop retrying and give up. If you need to stop retrying once
     * <b>cumulative</b> delay reaches a time-delay amount, use [[limitRetriesByCumulativeDelay]].
     */
-  def limitRetriesByDelay[F[_]: Applicative](
+  def limitRetriesByDelay[F[_]: Applicative, Res](
       threshold: FiniteDuration,
-      policy: RetryPolicy[F]
-  ): RetryPolicy[F] =
-    def decideNextRetry(status: RetryStatus): F[PolicyDecision] =
-      policy.decideNextRetry(status).map {
+      policy: RetryPolicy[F, Res]
+  ): RetryPolicy[F, Res] =
+    def decideNextRetry(actionResult: Res, status: RetryStatus): F[PolicyDecision] =
+      policy.decideNextRetry(actionResult, status).map {
         case r @ DelayAndRetry(delay) =>
           if delay > threshold then GiveUp else r
         case GiveUp => GiveUp
       }
 
-    RetryPolicy.withShow[F](
+    RetryPolicy.withShow[F, Res](
       decideNextRetry,
       show"limitRetriesByDelay(threshold=$threshold, $policy)"
     )
@@ -133,18 +131,18 @@ object RetryPolicies:
   /** Add an upperbound to a policy such that once the cumulative delay over all retries has reached or
     * exceeded the given limit, the policy will stop retrying and give up.
     */
-  def limitRetriesByCumulativeDelay[F[_]: Applicative](
+  def limitRetriesByCumulativeDelay[F[_]: Applicative, Res](
       threshold: FiniteDuration,
-      policy: RetryPolicy[F]
-  ): RetryPolicy[F] =
-    def decideNextRetry(status: RetryStatus): F[PolicyDecision] =
-      policy.decideNextRetry(status).map {
+      policy: RetryPolicy[F, Res]
+  ): RetryPolicy[F, Res] =
+    def decideNextRetry(actionResult: Res, status: RetryStatus): F[PolicyDecision] =
+      policy.decideNextRetry(actionResult, status).map {
         case r @ DelayAndRetry(delay) =>
           if status.cumulativeDelay + delay >= threshold then GiveUp else r
         case GiveUp => GiveUp
       }
 
-    RetryPolicy.withShow[F](
+    RetryPolicy.withShow[F, Res](
       decideNextRetry,
       show"limitRetriesByCumulativeDelay(threshold=$threshold, $policy)"
     )

--- a/modules/core/shared/src/main/scala/retry/syntax/RetrySyntax.scala
+++ b/modules/core/shared/src/main/scala/retry/syntax/RetrySyntax.scala
@@ -6,7 +6,7 @@ import retry.*
 extension [F[_], A](action: => F[A])
 
   def retryingOnFailures(
-      policy: RetryPolicy[F],
+      policy: RetryPolicy[F, A],
       valueHandler: ValueHandler[F, A]
   )(using T: Temporal[F]): F[Either[A, A]] =
     retry.retryingOnFailures(action)(
@@ -15,7 +15,7 @@ extension [F[_], A](action: => F[A])
     )
 
   def retryingOnErrors(
-      policy: RetryPolicy[F],
+      policy: RetryPolicy[F, Throwable],
       errorHandler: ErrorHandler[F, A]
   )(using T: Temporal[F]): F[A] =
     retry.retryingOnErrors(action)(
@@ -24,7 +24,7 @@ extension [F[_], A](action: => F[A])
     )
 
   def retryingOnFailuresAndErrors(
-      policy: RetryPolicy[F],
+      policy: RetryPolicy[F, Either[Throwable, A]],
       errorOrValueHandler: ErrorOrValueHandler[F, A]
   )(using T: Temporal[F]): F[Either[A, A]] =
     retry.retryingOnFailuresAndErrors(action)(

--- a/modules/core/shared/src/test/scala/retry/RetryPolicySuite.scala
+++ b/modules/core/shared/src/test/scala/retry/RetryPolicySuite.scala
@@ -11,15 +11,21 @@ class RetryPolicySuite extends FunSuite:
   test(
     "BoundedSemilattice append - gives up if either of the composed policies decides to give up"
   ) {
-    val alwaysGiveUp = RetryPolicy.lift[Id](_ => PolicyDecision.GiveUp)
+    val alwaysGiveUp = RetryPolicy.lift[Id, Any]((_, _) => PolicyDecision.GiveUp)
     val alwaysRetry  = RetryPolicies.constantDelay[Id](1.second)
 
     assertEquals(
-      (alwaysGiveUp |+| alwaysRetry).decideNextRetry(RetryStatus.NoRetriesYet),
+      (alwaysGiveUp |+| alwaysRetry).decideNextRetry(
+        (),
+        RetryStatus.NoRetriesYet
+      ),
       PolicyDecision.GiveUp
     )
     assertEquals(
-      (alwaysRetry |+| alwaysGiveUp).decideNextRetry(RetryStatus.NoRetriesYet),
+      (alwaysRetry |+| alwaysGiveUp).decideNextRetry(
+        (),
+        RetryStatus.NoRetriesYet
+      ),
       PolicyDecision.GiveUp
     )
   }
@@ -28,18 +34,20 @@ class RetryPolicySuite extends FunSuite:
     "BoundedSemilattice append - chooses the maximum of the delays if both of the composed policies decides to retry"
   ) {
     val delayOneSecond =
-      RetryPolicy.lift[Id](_ => PolicyDecision.DelayAndRetry(1.second))
+      RetryPolicy.lift[Id, Any]((_, _) => PolicyDecision.DelayAndRetry(1.second))
     val delayTwoSeconds =
-      RetryPolicy.lift[Id](_ => PolicyDecision.DelayAndRetry(2.seconds))
+      RetryPolicy.lift[Id, Any]((_, _) => PolicyDecision.DelayAndRetry(2.seconds))
 
     assertEquals(
       (delayOneSecond |+| delayTwoSeconds).decideNextRetry(
+        (),
         RetryStatus.NoRetriesYet
       ),
       PolicyDecision.DelayAndRetry(2.seconds)
     )
     assertEquals(
       (delayTwoSeconds |+| delayOneSecond).decideNextRetry(
+        (),
         RetryStatus.NoRetriesYet
       ),
       PolicyDecision.DelayAndRetry(2.seconds)

--- a/modules/docs/src/main/mdoc/docs/migration.md
+++ b/modules/docs/src/main/mdoc/docs/migration.md
@@ -9,6 +9,7 @@ The major changes in v4 are as follows:
 * **Scala 3**. The library is now published for Scala 3 only.
 * **Cats Effect**. The library is now more strongly coupled to Cats Effect.
 * **Adaption**. cats-retry now supports adaptation in the face of errors or failures.
+* **Dynamic retry policies**. Retry policies are now more powerful.
 * **API redesign**. The API has been completely rewritten to provide more power
 and flexibility with fewer combinators.
 
@@ -40,6 +41,17 @@ If you use the `alleycats` module, please stick with cats-retry v3.
 The biggest new feature in v4 is support for adaptation.
 
 Please see the [adaptation docs](./adaptation) for an explanation and a worked example.
+
+## Dynamic retry policies
+
+Retry policies now have access to the result of the action, so they can
+dynamically change their behaviour depending on the particular failure or error
+that occurred.
+
+This means that `RetryPolicy` now has an extra type parameter. All the built-in
+policies set this type param to `Any`.
+
+Please see the [retry policies docs](./policies) for more details.
 
 ## API redesign
 
@@ -83,7 +95,8 @@ def retryingOnFailures[F[_]: Temporal, A](
 
 The action is now passed as the first argument, not the last.
 
-The policy can be used without any changes.
+The policy can be used without any changes, assuming you have not implemented a
+custom retry policy.
 
 `wasSuccessful` and `onFailure` have been replaced by `valueHandler`. This is a
 function that takes the action's result and the retry details, does any
@@ -137,7 +150,8 @@ been removed.
 
 The action is now passed as the first argument, not the last.
 
-The policy can be used without any changes.
+The policy can be used without any changes, assuming you have not implemented a
+custom retry policy.
 
 `isWorthRetrying` and `onError` have been replaced by `errorHandler`. This is a
 function that takes the raised error and the retry details, does any necessary
@@ -186,7 +200,8 @@ been removed.
 
 The action is now passed as the first argument, not the last.
 
-The policy can be used without any changes.
+The policy can be used without any changes, assuming you have not implemented a
+custom retry policy.
 
 `onError` has been replaced by `errorHandler`. This is a function that takes the
 raised error and the retry details, does any necessary logging, and decides what
@@ -236,7 +251,8 @@ been removed.
 
 The action is now passed as the first argument, not the last.
 
-The policy can be used without any changes.
+The policy can be used without any changes, assuming you have not implemented a
+custom retry policy.
 
 `wasSuccessful`, `isWorthRetrying`, `onFailure` and `onError` have been replaced
 by a single `errorOrValueHandler`. This is a function that takes the action's
@@ -283,7 +299,8 @@ been removed.
 
 The action is now passed as the first argument, not the last.
 
-The policy can be used without any changes.
+The policy can be used without any changes, assuming you have not implemented a
+custom retry policy.
 
 `wasSuccessful`, `onFailure` and `onError` have been replaced by a single
 `errorOrValueHandler`. This is a function that takes the action's result or the

--- a/modules/docs/src/main/mdoc/docs/mtl-combinators.md
+++ b/modules/docs/src/main/mdoc/docs/mtl-combinators.md
@@ -132,11 +132,11 @@ case class AppError(reason: String)
 class Service[F[_]](client: util.FlakyHttpClient)(implicit F: Async[F], L: LiftIO[F], AH: Handle[F, AppError]) {
 
   // evaluates retry exclusively on errors produced by Handle
-  def findCoolCatGifRetryMtl(policy: RetryPolicy[F]): F[String] =
+  def findCoolCatGifRetryMtl(policy: RetryPolicy[F, Any]): F[String] =
     findCoolCatGif.retryingOnMtlErrors[AppError](policy, logAndRetryOnAllMtlErrors)
 
   // evaluates retry on errors produced by MonadError and Handle
-  def findCoolCatGifRetryAll(policy: RetryPolicy[F]): F[String] =
+  def findCoolCatGifRetryAll(policy: RetryPolicy[F, Any]): F[String] =
     findCoolCatGif
       .retryingOnErrors(policy, logAndRetryOnAllErrors)
       .retryingOnMtlErrors[AppError](policy, logAndRetryOnAllMtlErrors)

--- a/modules/mtl/shared/src/main/scala/retry/mtl/package.scala
+++ b/modules/mtl/shared/src/main/scala/retry/mtl/package.scala
@@ -12,7 +12,7 @@ import retry.*
 def retryingOnErrors[F[_], A, E](
     action: F[A]
 )(
-    policy: RetryPolicy[F],
+    policy: RetryPolicy[F, E],
     errorHandler: ResultHandler[F, E, A]
 )(using
     AH: Handle[F, E],
@@ -35,7 +35,7 @@ def retryingOnErrors[F[_], A, E](
  */
 
 private def retryingOnErrorsImpl[F[_], A, E](
-    policy: RetryPolicy[F],
+    policy: RetryPolicy[F, E],
     errorHandler: ResultHandler[F, E, A],
     status: RetryStatus,
     currentAction: F[A],
@@ -78,7 +78,7 @@ private def retryingOnErrorsImpl[F[_], A, E](
   attempt match
     case Left(error) =>
       for
-        nextStep <- applyPolicy(policy, status)
+        nextStep <- applyPolicy(policy, error, status)
         retryDetails = buildRetryDetails(status, nextStep)
         handlerDecision <- errorHandler(error, retryDetails)
         result          <- applyHandlerDecision(error, handlerDecision, nextStep)

--- a/modules/mtl/shared/src/main/scala/retry/mtl/syntax/RetrySyntax.scala
+++ b/modules/mtl/shared/src/main/scala/retry/mtl/syntax/RetrySyntax.scala
@@ -6,7 +6,7 @@ import retry.{ResultHandler, RetryPolicy}
 
 extension [F[_], A](action: F[A])
   def retryingOnMtlErrors[E](
-      policy: RetryPolicy[F],
+      policy: RetryPolicy[F, E],
       errorHandler: ResultHandler[F, E, A]
   )(using T: Temporal[F], AH: Handle[F, E]): F[A] =
     retry.mtl.retryingOnErrors(action)(


### PR DESCRIPTION
Fixes #506.

When asking the retry policy to decide the next step, pass the result of the last attempt. Depending on the combinator, this could be a value or an error.

Before:

```scala
case class RetryPolicy[F[_]](
    decideNextRetry: RetryStatus => F[PolicyDecision]
)
```

After:

```scala
case class RetryPolicy[F[_], -Res](
    decideNextRetry: (Res, RetryStatus) => F[PolicyDecision]
)
```

This allows users to implement more exotic retry policies, e.g. choosing to retry some kinds of error quickly, but using exponential backoff for others. I've added `RetryPolicies.dynamic` to support that.

All the built-in policies maintain their existing behaviour: they ignore the action result and decide the next step based on static rules.

This was quite a noisy change because it involved adding a new type parameter to `RetryPolicy`.