### PR TITLE
Configure the `versionScheme` property for sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ inThisBuild(
         url = url("https://github.com/ccantarero91")
       )
     ),
-    versionScheme := Some("semver-spec"),
+    versionScheme         := Some("semver-spec"),
     mimaPreviousArtifacts := Set.empty,
     scalafmtOnCompile     := false
   )

--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,7 @@ inThisBuild(
         url = url("https://github.com/ccantarero91")
       )
     ),
+    versionScheme := Some("semver-spec"),
     mimaPreviousArtifacts := Set.empty,
     scalafmtOnCompile     := false
   )


### PR DESCRIPTION
Sets the `versionScheme` property as `semver-spec`, which will prevent issues with `eviction` and the new `4` release.