### PR TITLE
Use Scaladex badge on ReadMe to show Scala version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img align="right" src="modules/docs/src/main/resources/microsite/img/cats-retry-logo.png" height="200px" style="padding-left: 20px"/>
 
-# cats-retry [![Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/typelevel/cats-retry)
+# cats-retry [![Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/typelevel/cats-retry) [![cats-retry Scala version support](https://index.scala-lang.org/cb372/cats-retry/cats-retry/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/cb372/cats-retry/cats-retry)
 
 A library for retrying actions that can fail.
 


### PR DESCRIPTION
Hi there! This Scaladex badge summarises which versions of Scala are supported by `cats-retry` (and what the latest `cats-retry` version is for each of those Scala versions):

[![cats-retry Scala version support](https://index.scala-lang.org/cb372/cats-retry/cats-retry/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/cb372/cats-retry/cats-retry)

More details on the badge format: https://github.com/scalacenter/scaladex/pull/660